### PR TITLE
Fix incorrect name for restart policy exit code

### DIFF
--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -147,7 +147,7 @@ const (
 	RestartPolicyOnFailure RestartPolicy = "OnFailure"
 	RestartPolicyNever     RestartPolicy = "Never"
 
-	// `ExitCode` policy means that user should add exit code by themselves,
+	// RestartPolicyExitCode policy means that user should add exit code by themselves,
 	// The job operator will check these exit codes to
 	// determine the behavior when an error occurs:
 	// - 1-127: permanent error, do not restart.


### PR DESCRIPTION
This should be `RestartPolicyExitCode` instead of `ExitCode`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/common/20)
<!-- Reviewable:end -->
