### PR TITLE
Add utility methods for job reconciliation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ script:
   # For now though we just run all tests in pkg.
   # And we can not use ** because goveralls uses filepath.Match
   # to match ignore files and it does not support it.
-  - goveralls -service=travis-ci -v -package ./... -ignore "client/*/*.go,client/*/*/*.go,client/*/*/*/*.go,client/*/*/*/*/*.go,client/*/*/*/*/*/*.go,client/*/*/*/*/*/*/*.go,testutil/*.go,test_job/*/zz_generated.*.go,test_job/*/*_generated.go,operator/*/zz_generated.*.go,operator/*/*_generated.go,job_controller/test_job_controller.go,job_controller/pod.go"
+  - goveralls -service=travis-ci -v -package ./... -ignore "client/*/*.go,client/*/*/*.go,client/*/*/*/*.go,client/*/*/*/*/*.go,client/*/*/*/*/*/*.go,client/*/*/*/*/*/*/*.go,testutil/*.go,test_job/*/zz_generated.*.go,test_job/*/*_generated.go,operator/*/zz_generated.*.go,operator/*/*_generated.go,job_controller/test_job_controller.go,job_controller/pod.go,job_controller/job.go"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ script:
   # For now though we just run all tests in pkg.
   # And we can not use ** because goveralls uses filepath.Match
   # to match ignore files and it does not support it.
-  - goveralls -service=travis-ci -v -package ./... -ignore "client/*/*.go,client/*/*/*.go,client/*/*/*/*.go,client/*/*/*/*/*.go,client/*/*/*/*/*/*.go,client/*/*/*/*/*/*/*.go,testutil/*.go,test_job/*/zz_generated.*.go,test_job/*/*_generated.go,operator/*/zz_generated.*.go,operator/*/*_generated.go,job_controller/test_job_controller.go,job_controller/pod.go,job_controller/job.go"
+  - goveralls -service=travis-ci -v -package ./... -ignore "client/*/*.go,client/*/*/*.go,client/*/*/*/*.go,client/*/*/*/*/*.go,client/*/*/*/*/*/*.go,client/*/*/*/*/*/*/*.go,testutil/*.go,test_job/*/zz_generated.*.go,test_job/*/*_generated.go,operator/*/zz_generated.*.go,operator/*/*_generated.go,job_controller/test_job_controller.go,job_controller/pod.go,job_controller/job.go,job_controller/status.go"

--- a/job_controller/job.go
+++ b/job_controller/job.go
@@ -1,12 +1,19 @@
 package job_controller
 
 import (
+	"fmt"
+	"reflect"
+	"strings"
 	"time"
 
 	common "github.com/kubeflow/common/operator/v1"
 	commonutil "github.com/kubeflow/common/util"
+	"github.com/kubeflow/common/util/k8sutil"
+	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 func (jc *JobController) deletePodsAndServices(runPolicy *common.RunPolicy, job interface{}, pods []*v1.Pod) error {
@@ -40,6 +47,236 @@ func (jc *JobController) cleanupJobIfTTL(runPolicy *common.RunPolicy, jobStatus 
 	ttl := runPolicy.TTLSecondsAfterFinished
 	if ttl == nil {
 		// do nothing if the cleanup delay is not set
+		return nil
+	}
+	duration := time.Second * time.Duration(*ttl)
+	if currentTime.After(jobStatus.CompletionTime.Add(duration)) {
+		err := jc.Controller.DeleteJob(job)
+		if err != nil {
+			commonutil.LoggerForJob(metaObject).Warnf("Cleanup Job error: %v.", err)
+			return err
+		}
+		return nil
+	}
+	key, err := KeyFunc(job)
+	if err != nil {
+		commonutil.LoggerForJob(metaObject).Warnf("Couldn't get key for job object: %v", err)
+		return err
+	}
+	jc.WorkQueue.AddRateLimited(key)
+	return nil
+}
+
+// ReconcileJobs checks and updates replicas for each given ReplicaSpec.
+// It will requeue the job in case of an error while creating/deleting pods/services.
+func (jc *JobController) ReconcileJobs(
+	job interface{},
+	replicas map[common.ReplicaType]*common.ReplicaSpec,
+	jobStatus common.JobStatus,
+	runPolicy *common.RunPolicy) error {
+
+	metaObject, ok := job.(metav1.Object)
+	jobName := metaObject.GetName()
+	if !ok {
+		return fmt.Errorf("job is not of type metav1.Object")
+	}
+	runtimeObject, ok := job.(runtime.Object)
+	if !ok {
+		return fmt.Errorf("job is not of type runtime.Object")
+	}
+	jobKey, err := KeyFunc(job)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for job object %#v: %v", job, err))
+		return err
+	}
+	log.Infof("Reconciling for job %s", metaObject.GetName())
+
+	oldStatus := jobStatus.DeepCopy()
+
+	pods, err := jc.GetPodsForJob(metaObject)
+
+	if err != nil {
+		log.Warnf("GetPodsForJob error %v", err)
+		return err
+	}
+
+	// TODO(terrytangyuan): Uncomment this once service reconciliation logic is in place
+	// services, err := jc.GetServicesForJob(metaObject)
+	//
+	// if err != nil {
+	// 	log.Warnf("GetServicesForJob error %v", err)
+	// 	return err
+	// }
+
+	// retrieve the previous number of retry
+	previousRetry := jc.WorkQueue.NumRequeues(jobKey)
+
+	activePods := k8sutil.FilterActivePods(pods)
+	active := int32(len(activePods))
+	failed := k8sutil.FilterPodCount(pods, v1.PodFailed)
+	totalReplicas := k8sutil.GetTotalReplicas(replicas)
+	prevReplicasFailedNum := k8sutil.GetTotalFailedReplicas(jobStatus.ReplicaStatuses)
+
+	var failureMessage string
+	jobExceedsLimit := false
+	exceedsBackoffLimit := false
+	pastBackoffLimit := false
+
+	if runPolicy.BackoffLimit != nil {
+		jobHasNewFailure := failed > prevReplicasFailedNum
+		// new failures happen when status does not reflect the failures and active
+		// is different than parallelism, otherwise the previous controller loop
+		// failed updating status so even if we pick up failure it is not a new one
+		exceedsBackoffLimit = jobHasNewFailure && (active != totalReplicas) &&
+			(int32(previousRetry)+1 > *runPolicy.BackoffLimit)
+
+		pastBackoffLimit, err = jc.pastBackoffLimit(jobName, runPolicy, replicas, pods)
+		if err != nil {
+			return err
+		}
+	}
+
+	if exceedsBackoffLimit || pastBackoffLimit {
+		// check if the number of pod restart exceeds backoff (for restart OnFailure only)
+		// OR if the number of failed jobs increased since the last syncJob
+		jobExceedsLimit = true
+		failureMessage = fmt.Sprintf("Job %s has failed because it has reached the specified backoff limit", jobName)
+	} else if jc.pastActiveDeadline(runPolicy, jobStatus) {
+		failureMessage = fmt.Sprintf("Job %s has failed because it was active longer than specified deadline", jobName)
+		jobExceedsLimit = true
+	}
+
+	// If the Job is terminated, delete all pods and services.
+	if isSucceeded(jobStatus) || isFailed(jobStatus) || jobExceedsLimit {
+		if err := jc.deletePodsAndServices(runPolicy, job, pods); err != nil {
+			return err
+		}
+
+		if err := jc.cleanupJob(runPolicy, jobStatus, job); err != nil {
+			return err
+		}
+
+		if jc.Config.EnableGangScheduling {
+			jc.Recorder.Event(runtimeObject, v1.EventTypeNormal, "JobTerminated", "Job has been terminated. Deleting PodGroup")
+			if err := jc.DeletePodGroup(metaObject); err != nil {
+				jc.Recorder.Eventf(runtimeObject, v1.EventTypeWarning, "FailedDeletePodGroup", "Error deleting: %v", err)
+				return err
+			} else {
+				jc.Recorder.Eventf(runtimeObject, v1.EventTypeNormal, "SuccessfulDeletePodGroup", "Deleted PodGroup: %v", jobName)
+
+			}
+		}
+
+		if jobExceedsLimit {
+			jc.Recorder.Event(runtimeObject, v1.EventTypeNormal, JobFailedReason, failureMessage)
+			if jobStatus.CompletionTime == nil {
+				now := metav1.Now()
+				jobStatus.CompletionTime = &now
+			}
+			err := updateJobConditions(&jobStatus, common.JobFailed, JobFailedReason, failureMessage)
+			if err != nil {
+				log.Infof("Append job condition error: %v", err)
+				return err
+			}
+		}
+
+		// At this point the pods may have been deleted.
+		// 1) If the job succeeded, we manually set the replica status.
+		// 2) If any replicas are still active, set their status to succeeded.
+		if isSucceeded(jobStatus) {
+			for rtype := range jobStatus.ReplicaStatuses {
+				jobStatus.ReplicaStatuses[rtype].Succeeded += jobStatus.ReplicaStatuses[rtype].Active
+				jobStatus.ReplicaStatuses[rtype].Active = 0
+			}
+		}
+		return jc.Controller.UpdateJobStatusInApiServer(job, &jobStatus)
+	}
+
+	// Save the current state of the replicas
+	replicasStatus := make(map[string]v1.PodPhase)
+
+	// Diff current active pods/services with replicas.
+	for rtype, spec := range replicas {
+		err = jc.ReconcilePods(metaObject, &jobStatus, pods, rtype, spec, replicasStatus, replicas)
+		if err != nil {
+			log.Warnf("ReconcilePods error %v", err)
+			return err
+		}
+
+		// TODO(terrytangyuan): Uncomment this once service reconciliation logic is in place
+		// err = jc.ReconcileServices(metaObject, services, rtype, spec)
+		//
+		// if err != nil {
+		// 	log.Warnf("ReconcileServices error %v", err)
+		// 	return err
+		// }
+	}
+
+	// No need to update the job status if the status hasn't changed since last time.
+	if !reflect.DeepEqual(*oldStatus, jobStatus) {
+		return jc.Controller.UpdateJobStatusInApiServer(job, &jobStatus)
+	}
+	return nil
+}
+
+// pastActiveDeadline checks if job has ActiveDeadlineSeconds field set and if it is exceeded.
+func (jc *JobController) pastActiveDeadline(runPolicy *common.RunPolicy, jobStatus common.JobStatus) bool {
+	if runPolicy.ActiveDeadlineSeconds == nil || jobStatus.StartTime == nil {
+		return false
+	}
+	now := metav1.Now()
+	start := jobStatus.StartTime.Time
+	duration := now.Time.Sub(start)
+	allowedDuration := time.Duration(*runPolicy.ActiveDeadlineSeconds) * time.Second
+	return duration >= allowedDuration
+}
+
+// pastBackoffLimit checks if container restartCounts sum exceeds BackoffLimit
+// this method applies only to pods with restartPolicy == OnFailure or Always
+func (jc *JobController) pastBackoffLimit(jobName string, runPolicy *common.RunPolicy,
+	replicas map[common.ReplicaType]*common.ReplicaSpec, pods []*v1.Pod) (bool, error) {
+	if runPolicy.BackoffLimit == nil {
+		return false, nil
+	}
+	result := int32(0)
+	for rtype, spec := range replicas {
+		if spec.RestartPolicy != common.RestartPolicyOnFailure && spec.RestartPolicy != common.RestartPolicyAlways {
+			log.Warnf("The restart policy of replica %v of the job %v is not OnFailure or Always. Not counted in backoff limit.", rtype, jobName)
+			continue
+		}
+		// Convert ReplicaType to lower string.
+		rt := strings.ToLower(string(rtype))
+		pods, err := jc.FilterPodsForReplicaType(pods, rt)
+		if err != nil {
+			return false, err
+		}
+		for i := range pods {
+			po := pods[i]
+			if po.Status.Phase != v1.PodRunning {
+				continue
+			}
+			for j := range po.Status.InitContainerStatuses {
+				stat := po.Status.InitContainerStatuses[j]
+				result += stat.RestartCount
+			}
+			for j := range po.Status.ContainerStatuses {
+				stat := po.Status.ContainerStatuses[j]
+				result += stat.RestartCount
+			}
+		}
+	}
+
+	if *runPolicy.BackoffLimit == 0 {
+		return result > 0, nil
+	}
+	return result >= *runPolicy.BackoffLimit, nil
+}
+
+func (jc *JobController) cleanupJob(runPolicy *common.RunPolicy, jobStatus common.JobStatus, job interface{}) error {
+	currentTime := time.Now()
+	metaObject, _ := job.(metav1.Object)
+	ttl := runPolicy.TTLSecondsAfterFinished
+	if ttl == nil {
 		return nil
 	}
 	duration := time.Second * time.Duration(*ttl)

--- a/job_controller/job_controller.go
+++ b/job_controller/job_controller.go
@@ -75,6 +75,9 @@ type ControllerInterface interface {
 	// UpdateJobStatus updates the job status and job conditions
 	UpdateJobStatus(job interface{}, replicas map[commonv1.ReplicaType]*commonv1.ReplicaSpec, jobStatus commonv1.JobStatus, restart bool) error
 
+	// UpdateJobStatusInApiServer updates the job status in API server
+	UpdateJobStatusInApiServer(job interface{}, jobStatus *commonv1.JobStatus) error
+
 	// CreateService creates the service
 	CreateService(job interface{}, service *v1.Service) error
 

--- a/job_controller/job_test.go
+++ b/job_controller/job_test.go
@@ -1,6 +1,7 @@
 package job_controller
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -83,6 +84,83 @@ func TestDeletePodsAndServices(T *testing.T) {
 	}
 }
 
+func TestPastBackoffLimit(T *testing.T) {
+	type testCase struct {
+		backOffLimit   int32
+		expectedResult bool
+	}
+
+	var testcase = []testCase{
+		{
+			int32(0),
+			false,
+		},
+	}
+
+	for _, tc := range testcase {
+		runningPod := newPod("runningPod", corev1.PodRunning)
+		succeededPod := newPod("succeededPod", corev1.PodSucceeded)
+		allPods := []*corev1.Pod{runningPod, succeededPod}
+
+		testJobController := TestJobController{
+			pods: allPods,
+		}
+
+		mainJobController := JobController{
+			Controller: &testJobController,
+		}
+		runPolicy := common.RunPolicy{
+			BackoffLimit: &tc.backOffLimit,
+		}
+
+		result, err := mainJobController.pastBackoffLimit("fake-job", &runPolicy, nil, allPods)
+
+		if assert.NoError(T, err) {
+			assert.Equal(T, result, tc.expectedResult)
+		}
+	}
+}
+
+func TestPastActiveDeadline(T *testing.T) {
+	type testCase struct {
+		activeDeadlineSeconds int64
+		expectedResult        bool
+	}
+
+	var testcase = []testCase{
+		{
+			int64(0),
+			true,
+		},
+		{
+			int64(2),
+			false,
+		},
+	}
+
+	for _, tc := range testcase {
+
+		testJobController := TestJobController{}
+
+		mainJobController := JobController{
+			Controller: &testJobController,
+		}
+		runPolicy := common.RunPolicy{
+			ActiveDeadlineSeconds: &tc.activeDeadlineSeconds,
+		}
+		jobStatus := common.JobStatus{
+			StartTime: &metav1.Time{
+				Time: time.Now(),
+			},
+		}
+
+		result := mainJobController.pastActiveDeadline(&runPolicy, jobStatus)
+		assert.Equal(
+			T, result, tc.expectedResult,
+			"Result is not expected for activeDeadlineSeconds == "+strconv.FormatInt(tc.activeDeadlineSeconds, 10))
+	}
+}
+
 func TestCleanupJobIfTTL(T *testing.T) {
 	ttl := int32(0)
 	runPolicy := common.RunPolicy{
@@ -108,6 +186,31 @@ func TestCleanupJobIfTTL(T *testing.T) {
 	err := mainJobController.cleanupJobIfTTL(&runPolicy, jobStatus, job)
 	if assert.NoError(T, err) {
 		// job field is zeroed
+		assert.Empty(T, testJobController.job)
+	}
+}
+
+func TestCleanupJob(T *testing.T) {
+	ttl := int32(0)
+	runPolicy := common.RunPolicy{
+		TTLSecondsAfterFinished: &ttl,
+	}
+	jobStatus := common.JobStatus{
+		CompletionTime: &metav1.Time{
+			Time: time.Now(),
+		},
+	}
+
+	testJobController := &TestJobController{
+		job: &v1.TestJob{},
+	}
+	mainJobController := JobController{
+		Controller: testJobController,
+	}
+
+	var job interface{}
+	err := mainJobController.cleanupJob(&runPolicy, jobStatus, job)
+	if assert.NoError(T, err) {
 		assert.Empty(T, testJobController.job)
 	}
 }

--- a/job_controller/job_test.go
+++ b/job_controller/job_test.go
@@ -21,19 +21,19 @@ func TestDeletePodsAndServices(T *testing.T) {
 
 	var testcase = []testCase{
 		{
-			common.CleanPodPolicyRunning,
-			true,
-			false,
+			cleanPodPolicy:               common.CleanPodPolicyRunning,
+			deleteRunningPodAndService:   true,
+			deleteSucceededPodAndService: false,
 		},
 		{
-			common.CleanPodPolicyAll,
-			true,
-			true,
+			cleanPodPolicy:               common.CleanPodPolicyAll,
+			deleteRunningPodAndService:   true,
+			deleteSucceededPodAndService: true,
 		},
 		{
-			common.CleanPodPolicyNone,
-			false,
-			false,
+			cleanPodPolicy:               common.CleanPodPolicyNone,
+			deleteRunningPodAndService:   false,
+			deleteSucceededPodAndService: false,
 		},
 	}
 
@@ -86,14 +86,14 @@ func TestDeletePodsAndServices(T *testing.T) {
 
 func TestPastBackoffLimit(T *testing.T) {
 	type testCase struct {
-		backOffLimit   int32
-		expectedResult bool
+		backOffLimit           int32
+		shouldPassBackoffLimit bool
 	}
 
 	var testcase = []testCase{
 		{
-			int32(0),
-			false,
+			backOffLimit:           int32(0),
+			shouldPassBackoffLimit: false,
 		},
 	}
 
@@ -116,25 +116,25 @@ func TestPastBackoffLimit(T *testing.T) {
 		result, err := mainJobController.pastBackoffLimit("fake-job", &runPolicy, nil, allPods)
 
 		if assert.NoError(T, err) {
-			assert.Equal(T, result, tc.expectedResult)
+			assert.Equal(T, result, tc.shouldPassBackoffLimit)
 		}
 	}
 }
 
 func TestPastActiveDeadline(T *testing.T) {
 	type testCase struct {
-		activeDeadlineSeconds int64
-		expectedResult        bool
+		activeDeadlineSeconds    int64
+		shouldPassActiveDeadline bool
 	}
 
 	var testcase = []testCase{
 		{
-			int64(0),
-			true,
+			activeDeadlineSeconds:    int64(0),
+			shouldPassActiveDeadline: true,
 		},
 		{
-			int64(2),
-			false,
+			activeDeadlineSeconds:    int64(2),
+			shouldPassActiveDeadline: false,
 		},
 	}
 
@@ -156,7 +156,7 @@ func TestPastActiveDeadline(T *testing.T) {
 
 		result := mainJobController.pastActiveDeadline(&runPolicy, jobStatus)
 		assert.Equal(
-			T, result, tc.expectedResult,
+			T, result, tc.shouldPassActiveDeadline,
 			"Result is not expected for activeDeadlineSeconds == "+strconv.FormatInt(tc.activeDeadlineSeconds, 10))
 	}
 }

--- a/job_controller/test_job_controller.go
+++ b/job_controller/test_job_controller.go
@@ -70,6 +70,10 @@ func (t *TestJobController) UpdateJobStatus(job interface{}, replicas map[common
 	return nil
 }
 
+func (t *TestJobController) UpdateJobStatusInApiServer(job interface{}, jobStatus *commonv1.JobStatus) error {
+	return nil
+}
+
 func (t *TestJobController) CreateService(job interface{}, service *corev1.Service) error {
 	return nil
 }


### PR DESCRIPTION
This PR adds utility methods for job reconciliation (part of https://github.com/kubeflow/common/issues/7). Note that part of the code is commented out for now until service reconciliation logic is in place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/common/24)
<!-- Reviewable:end -->
