### PR TITLE
make createNewPod public for custom operators.

### DIFF
--- a/job_controller/pod.go
+++ b/job_controller/pod.go
@@ -315,7 +315,7 @@ func (jc *JobController) ReconcilePods(
 
 			// check if this replica is the master role
 			masterRole = jc.Controller.IsMasterRole(replicas, rtype, index)
-			err = jc.createNewPod(job, rt, strconv.Itoa(index), spec, masterRole, replicas)
+			err = jc.CreateNewPod(job, rt, strconv.Itoa(index), spec, masterRole, replicas)
 			if err != nil {
 				return err
 			}
@@ -349,8 +349,8 @@ func (jc *JobController) ReconcilePods(
 	return jc.Controller.UpdateJobStatus(job, replicas, *jobStatus, restart)
 }
 
-// createNewPod creates a new pod for the given index and type.
-func (jc *JobController) createNewPod(job interface{}, rt, index string, spec *common.ReplicaSpec, masterRole bool,
+// CreateNewPod creates a new pod for the given index and type.
+func (jc *JobController) CreateNewPod(job interface{}, rt, index string, spec *common.ReplicaSpec, masterRole bool,
 	replicas map[common.ReplicaType]*common.ReplicaSpec) error {
 
 	metaObject, ok := job.(metav1.Object)


### PR DESCRIPTION
For now `createNewPod` is a private method and used in `ReconcilePods`, but for customized operators, the pod reconciliation is slightly different that we may asked to maintain and update other status, so we have to override the original `ReconcilePods` in common lib, then `createNewPod` can not be reused, so I propose to make this method public.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/common/31)
<!-- Reviewable:end -->
