### PR TITLE
set podInformer/serviceInformer in NewJobController

### DIFF
--- a/job_controller/job_controller.go
+++ b/job_controller/job_controller.go
@@ -191,6 +191,7 @@ func NewJobController(
 		EnableGangScheduling:     enableGangScheduling,
 	}
 
+
 	jc := JobController{
 		Controller:         controllerImpl,
 		Config:             jobControllerConfig,
@@ -202,8 +203,34 @@ func NewJobController(
 		WorkQueue:          workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), workQueueName),
 		Recorder:           recorder,
 	}
-	return jc
 
+	// Create pod informer.
+	podInformer := kubeInformerFactory.Core().V1().Pods()
+
+	// Set up an event handler for when pod resources change
+	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    jc.AddPod,
+		UpdateFunc: jc.UpdatePod,
+		DeleteFunc: jc.DeletePod,
+	})
+
+	jc.PodLister = podInformer.Lister()
+	jc.PodInformerSynced = podInformer.Informer().HasSynced
+
+	// Create service informer.
+	serviceInformer := kubeInformerFactory.Core().V1().Services()
+
+	// Set up an event handler for when service resources change.
+	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    jc.AddService,
+		UpdateFunc: jc.UpdateService,
+		DeleteFunc: jc.DeleteService,
+	})
+
+	jc.ServiceLister = serviceInformer.Lister()
+	jc.ServiceInformerSynced = serviceInformer.Informer().HasSynced
+
+	return jc
 }
 
 func (jc *JobController) GenOwnerReference(obj metav1.Object) *metav1.OwnerReference {

--- a/job_controller/job_controller_test.go
+++ b/job_controller/job_controller_test.go
@@ -1,0 +1,56 @@
+// Copyright 2019 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package job_controller
+
+import (
+	clientset "github.com/kubeflow/common/client/clientset/versioned"
+	kubebatchclient "github.com/kubernetes-sigs/kube-batch/pkg/client/clientset/versioned"
+	"k8s.io/api/core/v1"
+	kubeinformers "k8s.io/client-go/informers"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"testing"
+)
+
+func TestNewJobController(t *testing.T) {
+	// Prepare the clientset and controller for the test.
+	kubeClientSet := kubeclientset.NewForConfigOrDie(&rest.Config{
+		Host: "",
+		ContentConfig: rest.ContentConfig{
+			GroupVersion: &v1.SchemeGroupVersion,
+		},
+	},
+	)
+	// Prepare the kube-batch clientset and controller for the test.
+	kubeBatchClientSet := kubebatchclient.NewForConfigOrDie(&rest.Config{
+		Host: "",
+		ContentConfig: rest.ContentConfig{
+			GroupVersion: &v1.SchemeGroupVersion,
+		},
+	},
+	)
+
+	jobClientSet := clientset.NewForConfigOrDie(&rest.Config{
+		Host: "",
+		ContentConfig: rest.ContentConfig{
+			GroupVersion: &v1.SchemeGroupVersion,
+		},
+	},
+	)
+
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClientSet, 0)
+
+	NewTestJobController(kubeClientSet, kubeBatchClientSet, jobClientSet, kubeInformerFactory, true)
+}


### PR DESCRIPTION
Binding `podInformer` and `serviceInformer` onto jobController when we initialize a jobController by calling `NewJobController`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/common/34)
<!-- Reviewable:end -->
