### PR TITLE
refine arguments of ControllerInterface.UpdateJobStatus

### DIFF
--- a/job_controller/job.go
+++ b/job_controller/job.go
@@ -197,7 +197,7 @@ func (jc *JobController) ReconcileJobs(
 
 	// Diff current active pods/services with replicas.
 	for rtype, spec := range replicas {
-		err = jc.ReconcilePods(metaObject, &jobStatus, pods, rtype, spec, replicasStatus, replicas)
+		err := jc.ReconcilePods(metaObject, &jobStatus, pods, rtype, spec, replicasStatus, replicas)
 		if err != nil {
 			log.Warnf("ReconcilePods error %v", err)
 			return err
@@ -212,6 +212,11 @@ func (jc *JobController) ReconcileJobs(
 		// }
 	}
 
+	err = jc.Controller.UpdateJobStatus(job, replicas, &jobStatus)
+	if err != nil {
+		log.Warn("UpdateJobStatus error %v", err)
+		return err
+	}
 	// No need to update the job status if the status hasn't changed since last time.
 	if !reflect.DeepEqual(*oldStatus, jobStatus) {
 		return jc.Controller.UpdateJobStatusInApiServer(job, &jobStatus)

--- a/job_controller/job.go
+++ b/job_controller/job.go
@@ -214,7 +214,7 @@ func (jc *JobController) ReconcileJobs(
 
 	err = jc.Controller.UpdateJobStatus(job, replicas, &jobStatus)
 	if err != nil {
-		log.Warn("UpdateJobStatus error %v", err)
+		log.Warnf("UpdateJobStatus error %v", err)
 		return err
 	}
 	// No need to update the job status if the status hasn't changed since last time.

--- a/job_controller/job_controller.go
+++ b/job_controller/job_controller.go
@@ -59,7 +59,7 @@ type ControllerInterface interface {
 	DeleteJob(job interface{}) error
 
 	// UpdateJobStatus updates the job status and job conditions
-	UpdateJobStatus(job interface{}, replicas map[commonv1.ReplicaType]*commonv1.ReplicaSpec, jobStatus commonv1.JobStatus, restart bool) error
+	UpdateJobStatus(job interface{}, rtype commonv1.ReplicaType, replica *commonv1.ReplicaSpec, jobStatus commonv1.JobStatus, restart bool) error
 
 	// UpdateJobStatusInApiServer updates the job status in API server
 	UpdateJobStatusInApiServer(job interface{}, jobStatus *commonv1.JobStatus) error

--- a/job_controller/job_controller.go
+++ b/job_controller/job_controller.go
@@ -59,7 +59,7 @@ type ControllerInterface interface {
 	DeleteJob(job interface{}) error
 
 	// UpdateJobStatus updates the job status and job conditions
-	UpdateJobStatus(job interface{}, rtype commonv1.ReplicaType, replica *commonv1.ReplicaSpec, jobStatus commonv1.JobStatus, restart bool) error
+	UpdateJobStatus(job interface{}, replicas map[commonv1.ReplicaType]*commonv1.ReplicaSpec, jobStatus *commonv1.JobStatus) error
 
 	// UpdateJobStatusInApiServer updates the job status in API server
 	UpdateJobStatusInApiServer(job interface{}, jobStatus *commonv1.JobStatus) error

--- a/job_controller/pod.go
+++ b/job_controller/pod.go
@@ -346,7 +346,7 @@ func (jc *JobController) ReconcilePods(
 			updateJobReplicaStatuses(jobStatus, rtype, pod)
 		}
 	}
-	return jc.Controller.UpdateJobStatus(job, replicas, *jobStatus, restart)
+	return jc.Controller.UpdateJobStatus(job, rtype, replicas[rtype], *jobStatus, restart)
 }
 
 // createNewPod creates a new pod for the given index and type.

--- a/job_controller/pod.go
+++ b/job_controller/pod.go
@@ -301,7 +301,6 @@ func (jc *JobController) ReconcilePods(
 		return err
 	}
 	numReplicas := int(*spec.Replicas)
-	restart := false
 	var masterRole bool
 
 	initializeReplicaStatuses(jobStatus, rtype)
@@ -339,14 +338,13 @@ func (jc *JobController) ReconcilePods(
 					if err := jc.Controller.DeletePod(job, pod); err != nil {
 						return err
 					}
-					restart = true
 				}
 			}
 
 			updateJobReplicaStatuses(jobStatus, rtype, pod)
 		}
 	}
-	return jc.Controller.UpdateJobStatus(job, rtype, replicas[rtype], *jobStatus, restart)
+	return nil
 }
 
 // createNewPod creates a new pod for the given index and type.

--- a/job_controller/test_job_controller.go
+++ b/job_controller/test_job_controller.go
@@ -50,7 +50,7 @@ func (t *TestJobController) DeleteJob(job interface{}) error {
 	return nil
 }
 
-func (t *TestJobController) UpdateJobStatus(job interface{}, replica map[commonv1.ReplicaType]*commonv1.ReplicaSpec, jobStatus *commonv1.JobStatus) error {
+func (t *TestJobController) UpdateJobStatus(job interface{}, replicas map[commonv1.ReplicaType]*commonv1.ReplicaSpec, jobStatus *commonv1.JobStatus) error {
 	return nil
 }
 

--- a/job_controller/test_job_controller.go
+++ b/job_controller/test_job_controller.go
@@ -50,8 +50,7 @@ func (t *TestJobController) DeleteJob(job interface{}) error {
 	return nil
 }
 
-func (t *TestJobController) UpdateJobStatus(job interface{}, rtype commonv1.ReplicaType, replica *commonv1.ReplicaSpec,
-	jobStatus commonv1.JobStatus, restart bool) error {
+func (t *TestJobController) UpdateJobStatus(job interface{}, replica map[commonv1.ReplicaType]*commonv1.ReplicaSpec, jobStatus *commonv1.JobStatus) error {
 	return nil
 }
 

--- a/job_controller/test_job_controller.go
+++ b/job_controller/test_job_controller.go
@@ -50,7 +50,7 @@ func (t *TestJobController) DeleteJob(job interface{}) error {
 	return nil
 }
 
-func (t *TestJobController) UpdateJobStatus(job interface{}, replicas map[commonv1.ReplicaType]*commonv1.ReplicaSpec,
+func (t *TestJobController) UpdateJobStatus(job interface{}, rtype commonv1.ReplicaType, replica *commonv1.ReplicaSpec,
 	jobStatus commonv1.JobStatus, restart bool) error {
 	return nil
 }


### PR DESCRIPTION
Move `UpdateJobStatus` out of ReconcilePods loop, and remove bool arg(`restart`) which can be inferred from `replicas`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/common/35)
<!-- Reviewable:end -->
