### PR TITLE
GetDefaultContainerPortNumber to GetDefaultContainerPortName

### DIFF
--- a/job_controller/api/v1/interface.go
+++ b/job_controller/api/v1/interface.go
@@ -61,8 +61,11 @@ type ControllerInterface interface {
 	// Returns the default container name in pod
 	GetDefaultContainerName() string
 
-	// Get the default container port number
+	// Get the default container port name
 	GetDefaultContainerPortName() string
+
+	// Get the default container port number
+	GetDefaultContainerPortNumber() int32
 
 	// Returns if this replica type with index specified is a master role.
 	// MasterRole pod will have "job-role=master" set in its label

--- a/job_controller/api/v1/interface.go
+++ b/job_controller/api/v1/interface.go
@@ -62,7 +62,7 @@ type ControllerInterface interface {
 	GetDefaultContainerName() string
 
 	// Get the default container port number
-	GetDefaultContainerPortNumber() string
+	GetDefaultContainerPortName() string
 
 	// Returns if this replica type with index specified is a master role.
 	// MasterRole pod will have "job-role=master" set in its label

--- a/job_controller/service.go
+++ b/job_controller/service.go
@@ -171,7 +171,7 @@ func (jc *JobController) GetPortFromJob(spec *apiv1.ReplicaSpec) (int32, error) 
 		if container.Name == jc.Controller.GetDefaultContainerName() {
 			ports := container.Ports
 			for _, port := range ports {
-				if port.Name == jc.Controller.GetDefaultContainerPortNumber(){
+				if port.Name == jc.Controller.GetDefaultContainerPortName(){
 					return port.ContainerPort, nil
 				}
 			}

--- a/job_controller/service.go
+++ b/job_controller/service.go
@@ -213,7 +213,7 @@ func (jc *JobController) CreateNewService(job metav1.Object, rtype apiv1.Replica
 			Selector:  labels,
 			Ports: []v1.ServicePort{
 				{
-					Name: jc.Controller.GetDefaultContainerPortNumber(),
+					Name: jc.Controller.GetDefaultContainerPortName(),
 					Port: port,
 				},
 			},

--- a/job_controller/test_job_controller.go
+++ b/job_controller/test_job_controller.go
@@ -45,8 +45,8 @@ func (TestJobController) GetJobRoleKey() string {
 	return apiv1.JobRoleLabel
 }
 
-func (TestJobController) GetDefaultContainerPortNumber() string {
-	return "9999"
+func (TestJobController) GetDefaultContainerPortName() string {
+	return "default-port-name"
 }
 
 func (t *TestJobController) GetJobFromInformerCache(namespace, name string) (v1.Object, error) {

--- a/job_controller/test_job_controller.go
+++ b/job_controller/test_job_controller.go
@@ -49,6 +49,10 @@ func (TestJobController) GetDefaultContainerPortName() string {
 	return "default-port-name"
 }
 
+func (TestJobController) GetDefaultContainerPortNumber() int32 {
+	return int32(9999)
+}
+
 func (t *TestJobController) GetJobFromInformerCache(namespace, name string) (v1.Object, error) {
 	return t.job, nil
 }

--- a/test_job/v1/test_job_controller.go
+++ b/test_job/v1/test_job_controller.go
@@ -44,8 +44,8 @@ func (TestJobController) GetJobRoleKey() string {
 	return apiv1.JobRoleLabel
 }
 
-func (TestJobController) GetDefaultContainerPortNumber() string {
-	return "9999"
+func (TestJobController) GetDefaultContainerPortName() string {
+	return "default-port-name"
 }
 
 func (t *TestJobController) GetJobFromInformerCache(namespace, name string) (v1.Object, error) {

--- a/test_job/v1/test_job_controller.go
+++ b/test_job/v1/test_job_controller.go
@@ -48,6 +48,11 @@ func (TestJobController) GetDefaultContainerPortName() string {
 	return "default-port-name"
 }
 
+func (TestJobController) GetDefaultContainerPortNumber() int32 {
+	return int32(9999)
+}
+
+
 func (t *TestJobController) GetJobFromInformerCache(namespace, name string) (v1.Object, error) {
 	return t.Job, nil
 }


### PR DESCRIPTION
We need to get the port name of container for each job, so we would change the port number to port name in the job controller interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/common/41)
<!-- Reviewable:end -->
