### PR TITLE
Update openapi tag for SDK generating

### DIFF
--- a/job_controller/api/v1/doc.go
+++ b/job_controller/api/v1/doc.go
@@ -14,7 +14,6 @@
 
 // +k8s:deepcopy-gen=package,register
 // +k8s:defaulter-gen=TypeMeta
-// +k8s:openapi-gen=true
 
 // Package v1 is the v1 version of the API.
 // +groupName=kubeflow.org

--- a/job_controller/api/v1/types.go
+++ b/job_controller/api/v1/types.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=true
 // JobStatus represents the current observed state of the training Job.
 type JobStatus struct {
@@ -44,10 +45,12 @@ type JobStatus struct {
 	LastReconcileTime *metav1.Time `json:"lastReconcileTime,omitempty"`
 }
 
+// +k8s:openapi-gen=true
 // ReplicaType represents the type of the replica. Each operator needs to define its
 // own set of ReplicaTypes.
 type ReplicaType string
 
+// +k8s:openapi-gen=true
 // ReplicaStatus represents the current observed state of the replica.
 type ReplicaStatus struct {
 	// The number of actively running pods.
@@ -60,6 +63,7 @@ type ReplicaStatus struct {
 	Failed int32 `json:"failed,omitempty"`
 }
 
+// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=true
 // ReplicaSpec is a description of the replica
 type ReplicaSpec struct {
@@ -78,6 +82,7 @@ type ReplicaSpec struct {
 	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty"`
 }
 
+// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=true
 // JobCondition describes the state of the job at a certain point.
 type JobCondition struct {
@@ -126,6 +131,7 @@ const (
 	JobFailed JobConditionType = "Failed"
 )
 
+// +k8s:openapi-gen=true
 // CleanPodPolicy describes how to deal with pods when the job is finished.
 type CleanPodPolicy string
 


### PR DESCRIPTION
In the PR https://github.com/kubeflow/tf-operator/pull/1103, we generate SDK using openapi  -> swagger ways, tfjob depends on common repo, the PR is current the openapi generate flag so that the current types can be involved. See more in https://github.com/kubeflow/tf-operator/pull/1103.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/common/49)
<!-- Reviewable:end -->
