### PR TITLE
Remove unnecessary comment on gometalinter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ go_import_path: github.com/kubeflow/common
 install:
   # get coveralls.io support
   - go get github.com/mattn/goveralls
-  # gometalinter is deprecated; migrating to golangci-lint. See https://github.com/alecthomas/gometalinter/issues/590.
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
 
 script:


### PR DESCRIPTION
The deprecation of gometalinter is official so this comment isn't necessary anymore. 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/common/50)
<!-- Reviewable:end -->
