### PR TITLE
Move Pods/Services control interface to separate folder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	k8s.io/client-go v0.16.9-beta.0
 	k8s.io/code-generator v0.15.10
 	k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30
-	k8s.io/kubernetes v1.18.0
+	k8s.io/kubernetes v1.16.2
 	volcano.sh/volcano v0.4.0
 )
 
@@ -39,7 +39,7 @@ replace (
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.15.10
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.15.10
 	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.15.10
-	k8s.io/kubectl => k8s.io/kubectl v0.15.11-beta.0
+	k8s.io/kubectl => k8s.io/kubectl v0.15.10
 	k8s.io/kubelet => k8s.io/kubelet v0.15.10
 	k8s.io/kubernetes => k8s.io/kubernetes v1.15.10
 	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.15.10

--- a/pkg/controller.v1/common/pod.go
+++ b/pkg/controller.v1/common/pod.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"fmt"
+	"github.com/kubeflow/common/pkg/controller.v1/control"
 	"reflect"
 	"strconv"
 	"strings"
@@ -437,14 +438,14 @@ func (jc *JobController) createNewPod(job interface{}, rt, index string, spec *a
 
 func (jc *JobController) createPodWithControllerRef(namespace string, template *v1.PodTemplateSpec,
 	controllerObject runtime.Object, controllerRef *metav1.OwnerReference) error {
-	if err := validateControllerRef(controllerRef); err != nil {
+	if err := control.ValidateControllerRef(controllerRef); err != nil {
 		return err
 	}
 	return jc.createPod("", namespace, template, controllerObject, controllerRef)
 }
 
 func (jc *JobController) createPod(nodeName, namespace string, template *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error {
-	pod, err := GetPodFromTemplate(template, object, controllerRef)
+	pod, err := control.GetPodFromTemplate(template, object, controllerRef)
 	pod.Namespace = namespace
 	if err != nil {
 		return err
@@ -456,7 +457,7 @@ func (jc *JobController) createPod(nodeName, namespace string, template *v1.PodT
 		return fmt.Errorf("unable to create pods, no labels")
 	}
 	if err := jc.Controller.CreatePod(object, pod); err != nil {
-		jc.Recorder.Eventf(object, v1.EventTypeWarning, FailedCreatePodReason, "Error creating: %v", err)
+		jc.Recorder.Eventf(object, v1.EventTypeWarning, control.FailedCreatePodReason, "Error creating: %v", err)
 		return err
 	} else {
 		logger := commonutil.LoggerForPod(pod, jc.Controller.GetAPIGroupVersionKind().Kind)
@@ -466,7 +467,7 @@ func (jc *JobController) createPod(nodeName, namespace string, template *v1.PodT
 			return nil
 		}
 		logger.Infof("Controller %v created pod %v", accessor.GetName(), pod.Name)
-		jc.Recorder.Eventf(object, v1.EventTypeNormal, SuccessfulCreatePodReason, "Created pod: %v", pod.Name)
+		jc.Recorder.Eventf(object, v1.EventTypeNormal, control.SuccessfulCreatePodReason, "Created pod: %v", pod.Name)
 	}
 	return nil
 }

--- a/pkg/controller.v1/control/pod_control.go
+++ b/pkg/controller.v1/control/pod_control.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package control
 
 import (
 	"fmt"
@@ -79,14 +79,14 @@ func (r RealPodControl) CreatePods(namespace string, template *v1.PodTemplateSpe
 }
 
 func (r RealPodControl) CreatePodsWithControllerRef(namespace string, template *v1.PodTemplateSpec, controllerObject runtime.Object, controllerRef *metav1.OwnerReference) error {
-	if err := validateControllerRef(controllerRef); err != nil {
+	if err := ValidateControllerRef(controllerRef); err != nil {
 		return err
 	}
 	return r.createPods("", namespace, template, controllerObject, controllerRef)
 }
 
 func (r RealPodControl) CreatePodsOnNode(nodeName, namespace string, template *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error {
-	if err := validateControllerRef(controllerRef); err != nil {
+	if err := ValidateControllerRef(controllerRef); err != nil {
 		return err
 	}
 	return r.createPods(nodeName, namespace, template, object, controllerRef)

--- a/pkg/controller.v1/control/pod_control_test.go
+++ b/pkg/controller.v1/control/pod_control_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package control
 
 import (
 	"encoding/json"

--- a/pkg/controller.v1/control/service_control_test.go
+++ b/pkg/controller.v1/control/service_control_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package control
 
 import (
 	"encoding/json"

--- a/pkg/controller.v1/control/service_ref_manager.go
+++ b/pkg/controller.v1/control/service_ref_manager.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package control
 
 import (
 	"fmt"

--- a/pkg/controller.v1/control/service_ref_manager_test.go
+++ b/pkg/controller.v1/control/service_ref_manager_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package control
 
 import (
 	testutilv1 "github.com/kubeflow/common/test_job/test_util/v1"

--- a/pkg/controller.v1/control/utils.go
+++ b/pkg/controller.v1/control/utils.go
@@ -1,0 +1,35 @@
+package control
+
+import (
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func ValidateControllerRef(controllerRef *metav1.OwnerReference) error {
+	if controllerRef == nil {
+		return fmt.Errorf("controllerRef is nil")
+	}
+	if len(controllerRef.APIVersion) == 0 {
+		return fmt.Errorf("controllerRef has empty APIVersion")
+	}
+	if len(controllerRef.Kind) == 0 {
+		return fmt.Errorf("controllerRef has empty Kind")
+	}
+	if controllerRef.Controller == nil || !*controllerRef.Controller {
+		return fmt.Errorf("controllerRef.Controller is not set to true")
+	}
+	if controllerRef.BlockOwnerDeletion == nil || !*controllerRef.BlockOwnerDeletion {
+		return fmt.Errorf("controllerRef.BlockOwnerDeletion is not set")
+	}
+	return nil
+}
+
+func GetServiceFromTemplate(template *v1.Service, parentObject runtime.Object, controllerRef *metav1.OwnerReference) (*v1.Service, error) {
+	service := template.DeepCopy()
+	if controllerRef != nil {
+		service.OwnerReferences = append(service.OwnerReferences, *controllerRef)
+	}
+	return service, nil
+}


### PR DESCRIPTION
Currently, pods/services implementation mixed with jobController together under `common` folder, this is a little messy. 

The reason we want to have separate folder (package name) for it are
1. PodControlInterface is folked from [controller_util.go](https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/controller/controller_utils.go) and we also implement similar codes for service. They are logically separate. For long term, once https://github.com/kubernetes/client-go/issues/332 is merged, we could remove the folder entirely.

2.  Since `PodControlInterface` and `ServiceControlInterface` are internal code base for common project, there's no need for users to import them at all. 

3. Trying to make some changes inside `control` to solve #48. It would be better to file this PR first and make changes against new folder, that would be easier for review. Otherwise, it's a new file. 