### PR TITLE
Update comments on the use of -ignore flag for goveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,7 @@ script:
   - ./hack/verify-codegen.sh
   - go build ./...
   - golangci-lint run ./...
-  # We customize the build step because by default
-  # Travis runs go test -v ./... which will include the vendor
-  # directory.
-  # With go 1.9 vendor will be automatically excluded.
-  # For now though we just run all tests in pkg.
-  # And we can not use ** because goveralls uses filepath.Match
-  # to match ignore files and it does not support it.
+  # Here we run all tests in pkg and we have to use `-ignore`
+  # since goveralls uses `filepath.Match` to match ignore files
+  # and it does not support patterns like `**`.
   - goveralls -service=travis-ci -v -package ./... -ignore "test_job/client/*/*.go,test_job/client/*/*/*.go,test_job/client/*/*/*/*.go,test_job/client/*/*/*/*/*.go,test_job/client/*/*/*/*/*/*.go,test_job/client/*/*/*/*/*/*/*.go,test_job/testutil/*.go,test_job/*/*/*/zz_generated.*.go,test_job/*/*/*/*_generated.go,pkg/apis/common/*/zz_generated.*.go,pkg/apis/common/*/*_generated.go"


### PR DESCRIPTION
We no longer have vendor directories.