### PR TITLE
Simplify interfaces and remove useless interfaces

### DIFF
--- a/pkg/apis/common/v1/interface.go
+++ b/pkg/apis/common/v1/interface.go
@@ -26,14 +26,6 @@ type ControllerInterface interface {
 	// Returns the Job from API server
 	GetJobFromAPIClient(namespace, name string) (metav1.Object, error)
 
-	// GetPodsForJob returns the pods managed by the job. This can be achieved by selecting pods using label key "job-name"
-	// i.e. all pods created by the job will come with label "job-name" = <this_job_name>
-	GetPodsForJob(job interface{}) ([]*v1.Pod, error)
-
-	// GetServicesForJob returns the services managed by the job. This can be achieved by selecting services using label key "job-name"
-	// i.e. all services created by the job will come with label "job-name" = <this_job_name>
-	GetServicesForJob(job interface{}) ([]*v1.Service, error)
-
 	// DeleteJob deletes the job
 	DeleteJob(job interface{}) error
 
@@ -42,18 +34,6 @@ type ControllerInterface interface {
 
 	// UpdateJobStatusInApiServer updates the job status in API server
 	UpdateJobStatusInApiServer(job interface{}, jobStatus *JobStatus) error
-
-	// CreateService creates the service
-	CreateService(job interface{}, service *v1.Service) error
-
-	// DeleteService deletes the service
-	DeleteService(job interface{}, name string, namespace string) error
-
-	// CreatePod creates the pod
-	CreatePod(job interface{}, pod *v1.Pod) error
-
-	// DeletePod deletes the pod
-	DeletePod(job interface{}, pod *v1.Pod) error
 
 	// SetClusterSpec sets the cluster spec for the pod
 	SetClusterSpec(job interface{}, podTemplate *v1.PodTemplateSpec, rtype, index string) error

--- a/pkg/apis/common/v1/interface.go
+++ b/pkg/apis/common/v1/interface.go
@@ -44,9 +44,6 @@ type ControllerInterface interface {
 	// Get the default container port name
 	GetDefaultContainerPortName() string
 
-	// Get the default container port number
-	GetDefaultContainerPortNumber() int32
-
 	// Returns if this replica type with index specified is a master role.
 	// MasterRole pod will have "job-role=master" set in its label
 	IsMasterRole(replicas map[ReplicaType]*ReplicaSpec, rtype ReplicaType, index int) bool

--- a/pkg/controller.v1/common/job_controller.go
+++ b/pkg/controller.v1/common/job_controller.go
@@ -15,7 +15,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	apiv1 "github.com/kubeflow/common/pkg/apis/common/v1"
-	"github.com/kubeflow/common/pkg/controller.v1/expectation"
 	log "github.com/sirupsen/logrus"
 	policyapi "k8s.io/api/policy/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/controller.v1/common/job_controller.go
+++ b/pkg/controller.v1/common/job_controller.go
@@ -15,6 +15,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	apiv1 "github.com/kubeflow/common/pkg/apis/common/v1"
+	"github.com/kubeflow/common/pkg/controller.v1/control"
+	"github.com/kubeflow/common/pkg/controller.v1/expectation"
 	log "github.com/sirupsen/logrus"
 	policyapi "k8s.io/api/policy/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -25,8 +27,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"volcano.sh/volcano/pkg/apis/scheduling/v1beta1"
-	"github.com/kubeflow/common/pkg/controller.v1/control"
-	"github.com/kubeflow/common/pkg/controller.v1/expectation"
 	volcanoclient "volcano.sh/volcano/pkg/client/clientset/versioned"
 )
 
@@ -156,12 +156,12 @@ func NewJobController(
 
 	podControl := control.RealPodControl{
 		KubeClient: kubeClientSet,
-		Recorder: eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: controllerImpl.ControllerName()}),
+		Recorder:   eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: controllerImpl.ControllerName()}),
 	}
 
 	serviceControl := control.RealServiceControl{
 		KubeClient: kubeClientSet,
-		Recorder: eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: controllerImpl.ControllerName()}),
+		Recorder:   eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: controllerImpl.ControllerName()}),
 	}
 
 	jobControllerConfig := JobControllerConfiguration{

--- a/pkg/controller.v1/common/job_controller.go
+++ b/pkg/controller.v1/common/job_controller.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"volcano.sh/volcano/pkg/apis/scheduling/v1beta1"
+	"github.com/kubeflow/common/pkg/controller.v1/control"
+	"github.com/kubeflow/common/pkg/controller.v1/expectation"
 	volcanoclient "volcano.sh/volcano/pkg/client/clientset/versioned"
 )
 
@@ -83,6 +85,12 @@ type JobController struct {
 	Controller apiv1.ControllerInterface
 
 	Config JobControllerConfiguration
+
+	// podControl is used to add or delete pods.
+	PodControl control.PodControlInterface
+
+	// serviceControl is used to add or delete services.
+	ServiceControl control.ServiceControlInterface
 
 	// KubeClientSet is a standard kubernetes clientset.
 	KubeClientSet kubeclientset.Interface
@@ -147,6 +155,16 @@ func NewJobController(
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeClientSet.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: controllerImpl.ControllerName()})
 
+	podControl := control.RealPodControl{
+		KubeClient: kubeClientSet,
+		Recorder: eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: controllerImpl.ControllerName()}),
+	}
+
+	serviceControl := control.RealServiceControl{
+		KubeClient: kubeClientSet,
+		Recorder: eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: controllerImpl.ControllerName()}),
+	}
+
 	jobControllerConfig := JobControllerConfiguration{
 		ReconcilerSyncLoopPeriod: reconcilerSyncPeriod,
 		EnableGangScheduling:     enableGangScheduling,
@@ -155,6 +173,8 @@ func NewJobController(
 	jc := JobController{
 		Controller:       controllerImpl,
 		Config:           jobControllerConfig,
+		PodControl:       podControl,
+		ServiceControl:   serviceControl,
 		KubeClientSet:    kubeClientSet,
 		VolcanoClientSet: volcanoClientSet,
 		Expectations:     expectation.NewControllerExpectations(),

--- a/pkg/controller.v1/common/pod.go
+++ b/pkg/controller.v1/common/pod.go
@@ -49,7 +49,7 @@ const (
 	// podTemplateSchedulerNameReason is the warning reason when other scheduler name is set
 	// in pod templates with gang-scheduling enabled
 	podTemplateSchedulerNameReason = "SettedPodTemplateSchedulerName"
-
+	// gangSchedulingPodGroupAnnotation is the annotation key used by batch schedulers
 	gangSchedulingPodGroupAnnotation = "scheduling.k8s.io/group-name"
 )
 
@@ -481,7 +481,10 @@ func (jc *JobController) createNewPod(job interface{}, rt, index string, spec *a
 		if podTemplate.Annotations == nil {
 			podTemplate.Annotations = map[string]string{}
 		}
-		podTemplate.Annotations[gangSchedulingPodGroupAnnotation] = metaObject.GetName()
+
+		if jc.Config.EnableGangScheduling {
+			podTemplate.Annotations[gangSchedulingPodGroupAnnotation] = metaObject.GetName()
+		}
 	}
 
 	controllerRef := jc.GenOwnerReference(metaObject)

--- a/pkg/controller.v1/common/pod.go
+++ b/pkg/controller.v1/common/pod.go
@@ -20,19 +20,18 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/kubeflow/common/pkg/controller.v1/control"
 	"github.com/kubeflow/common/pkg/controller.v1/expectation"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/kubernetes/pkg/controller"
 
 	apiv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 	commonutil "github.com/kubeflow/common/pkg/util"
@@ -50,6 +49,8 @@ const (
 	// podTemplateSchedulerNameReason is the warning reason when other scheduler name is set
 	// in pod templates with gang-scheduling enabled
 	podTemplateSchedulerNameReason = "SettedPodTemplateSchedulerName"
+
+	gangSchedulingPodGroupAnnotation = "scheduling.k8s.io/group-name"
 )
 
 var (
@@ -212,6 +213,46 @@ func (jc *JobController) DeletePod(obj interface{}) {
 	jc.WorkQueue.Add(jobKey)
 }
 
+// getPodsForJob returns the set of pods that this job should manage.
+// It also reconciles ControllerRef by adopting/orphaning.
+// Note that the returned Pods are pointers into the cache.
+func (jc *JobController) GetPodsForJob(jobObject interface{}) ([]*v1.Pod, error) {
+	job, ok := jobObject.(metav1.Object)
+	if !ok {
+		return nil, fmt.Errorf("job is not of type metav1.Object")
+	}
+
+	// Create selector.
+	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels: jc.GenLabels(job.GetName()),
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("couldn't convert Job selector: %v", err)
+	}
+	// List all pods to include those that don't match the selector anymore
+	// but have a ControllerRef pointing to this controller.
+	pods, err := jc.PodLister.Pods(job.GetNamespace()).List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	// If any adoptions are attempted, we should first recheck for deletion
+	// with an uncached quorum read sometime after listing Pods (see #42639).
+	canAdoptFunc := RecheckDeletionTimestamp(func() (metav1.Object, error) {
+		fresh, err := jc.Controller.GetJobFromAPIClient(job.GetNamespace(), job.GetName())
+		if err != nil {
+			return nil, err
+		}
+		if fresh.GetUID() != job.GetUID() {
+			return nil, fmt.Errorf("original Job %v/%v is gone: got uid %v, wanted %v", job.GetNamespace(), job.GetName(), fresh.GetUID(), job.GetUID())
+		}
+		return fresh, nil
+	})
+	cm := controller.NewPodControllerRefManager(jc.PodControl, job, selector, jc.Controller.GetAPIGroupVersionKind(), canAdoptFunc)
+	return cm.ClaimPods(pods)
+}
+
 // FilterPodsForReplicaType returns pods belong to a replicaType.
 func (jc *JobController) FilterPodsForReplicaType(pods []*v1.Pod, replicaType string) ([]*v1.Pod, error) {
 	var result []*v1.Pod
@@ -284,7 +325,6 @@ func (jc *JobController) ReconcilePods(
 	pods []*v1.Pod,
 	rtype apiv1.ReplicaType,
 	spec *apiv1.ReplicaSpec,
-	rstatus map[string]v1.PodPhase,
 	replicas map[apiv1.ReplicaType]*apiv1.ReplicaSpec) error {
 
 	metaObject, ok := job.(metav1.Object)
@@ -334,7 +374,7 @@ func (jc *JobController) ReconcilePods(
 
 			// check if the index is in the valid range, if not, we should kill the pod
 			if index < 0 || index >= numReplicas {
-				err = jc.Controller.DeletePod(job, pod)
+				err = jc.PodControl.DeletePod(pod.Namespace, pod.Name, runtimeObject)
 				if err != nil {
 					return err
 				}
@@ -355,7 +395,7 @@ func (jc *JobController) ReconcilePods(
 				if pod.Status.Phase == v1.PodFailed && trainutil.IsRetryableExitCode(exitCode) {
 					failedPodsCount.Inc()
 					logger.Infof("Need to restart the pod: %v.%v", pod.Namespace, pod.Name)
-					if err := jc.Controller.DeletePod(job, pod); err != nil {
+					if err := jc.PodControl.DeletePod(pod.Namespace, pod.Name, runtimeObject); err != nil {
 						return err
 					}
 				}
@@ -437,10 +477,15 @@ func (jc *JobController) createNewPod(job interface{}, rt, index string, spec *a
 		} else {
 			podTemplate.Spec.SchedulerName = gangSchedulerName
 		}
-	}
-	controllerRef := jc.GenOwnerReference(metaObject)
 
-	err = jc.createPodWithControllerRef(metaObject.GetNamespace(), podTemplate, runtimeObject, controllerRef)
+		if podTemplate.Annotations == nil {
+			podTemplate.Annotations = map[string]string{}
+		}
+		podTemplate.Annotations[gangSchedulingPodGroupAnnotation] = metaObject.GetName()
+	}
+
+	controllerRef := jc.GenOwnerReference(metaObject)
+	err = jc.PodControl.CreatePodsWithControllerRef(metaObject.GetNamespace(), podTemplate, runtimeObject, controllerRef)
 	if err != nil && errors.IsTimeout(err) {
 		// Pod is created but its initialization has timed out.
 		// If the initialization is successful eventually, the
@@ -453,43 +498,7 @@ func (jc *JobController) createNewPod(job interface{}, rt, index string, spec *a
 	} else if err != nil {
 		return err
 	}
-	return nil
-}
-
-func (jc *JobController) createPodWithControllerRef(namespace string, template *v1.PodTemplateSpec,
-	controllerObject runtime.Object, controllerRef *metav1.OwnerReference) error {
-	if err := control.ValidateControllerRef(controllerRef); err != nil {
-		return err
-	}
-	return jc.createPod("", namespace, template, controllerObject, controllerRef)
-}
-
-func (jc *JobController) createPod(nodeName, namespace string, template *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference) error {
-	pod, err := control.GetPodFromTemplate(template, object, controllerRef)
-	pod.Namespace = namespace
-	if err != nil {
-		return err
-	}
-	if len(nodeName) != 0 {
-		pod.Spec.NodeName = nodeName
-	}
-	if labels.Set(pod.Labels).AsSelectorPreValidated().Empty() {
-		return fmt.Errorf("unable to create pods, no labels")
-	}
-	if err := jc.Controller.CreatePod(object, pod); err != nil {
-		jc.Recorder.Eventf(object, v1.EventTypeWarning, control.FailedCreatePodReason, "Error creating: %v", err)
-		return err
-	} else {
-		logger := commonutil.LoggerForPod(pod, jc.Controller.GetAPIGroupVersionKind().Kind)
-		accessor, err := meta.Accessor(object)
-		if err != nil {
-			logger.Errorf("parentObject does not have ObjectMeta, %v", err)
-			return nil
-		}
-		createdPodsCount.Inc()
-		logger.Infof("Controller %v created pod %v", accessor.GetName(), pod.Name)
-		jc.Recorder.Eventf(object, v1.EventTypeNormal, control.SuccessfulCreatePodReason, "Created pod: %v", pod.Name)
-	}
+	createdPodsCount.Inc()
 	return nil
 }
 

--- a/pkg/controller.v1/common/service.go
+++ b/pkg/controller.v1/common/service.go
@@ -328,9 +328,12 @@ func (jc *JobController) CreateNewService(job metav1.Object, rtype apiv1.Replica
 		// uninitialized for a long time, the informer will not
 		// receive any update, and the controller will create a new
 		// service when the expectation expires.
+		succeededServiceCreationCount.Inc()
 		return nil
 	} else if err != nil {
+		failedServiceCreationCount.Inc()
 		return err
 	}
+	succeededServiceCreationCount.Inc()
 	return nil
 }

--- a/pkg/controller.v1/common/service.go
+++ b/pkg/controller.v1/common/service.go
@@ -27,7 +27,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -95,6 +94,46 @@ func (jc *JobController) UpdateService(old, cur interface{}) {
 // obj could be an *v1.Service, or a DeletionFinalStateUnknown marker item.
 func (jc *JobController) DeleteService(obj interface{}) {
 	// TODO(CPH): handle this gracefully.
+}
+
+// getServicesForJob returns the set of services that this job should manage.
+// It also reconciles ControllerRef by adopting/orphaning.
+// Note that the returned services are pointers into the cache.
+func (jc *JobController) GetServicesForJob(jobObject interface{}) ([]*v1.Service, error) {
+	job, ok := jobObject.(metav1.Object)
+	if !ok {
+		return nil, fmt.Errorf("job is not of type metav1.Object")
+	}
+
+	// Create selector
+	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels: jc.GenLabels(job.GetName()),
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("couldn't convert Job selector: %v", err)
+	}
+	// List all services to include those that don't match the selector anymore
+	// but have a ControllerRef pointing to this controller.
+	services, err := jc.ServiceLister.Services(job.GetNamespace()).List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	// If any adoptions are attempted, we should first recheck for deletion
+	// with an uncached quorum read sometime after listing services (see #42639).
+	canAdoptFunc := RecheckDeletionTimestamp(func() (metav1.Object, error) {
+		fresh, err := jc.Controller.GetJobFromInformerCache(job.GetNamespace(), job.GetName())
+		if err != nil {
+			return nil, err
+		}
+		if fresh.GetUID() != job.GetUID() {
+			return nil, fmt.Errorf("original Job %v/%v is gone: got uid %v, wanted %v", job.GetNamespace(), job.GetName(), fresh.GetUID(), job.GetUID())
+		}
+		return fresh, nil
+	})
+	cm := control.NewServiceControllerRefManager(jc.ServiceControl, job, selector, jc.Controller.GetAPIGroupVersionKind(), canAdoptFunc)
+	return cm.ClaimServices(services)
 }
 
 // FilterServicesForReplicaType returns service belong to a replicaType.
@@ -203,7 +242,7 @@ func (jc *JobController) ReconcileServices(
 
 			// check if the index is in the valid range, if not, we should kill the svc
 			if index < 0 || index >= replicas {
-				err = jc.Controller.DeleteService(job, svc.Name, svc.Namespace)
+				err = jc.ServiceControl.DeleteService(svc.Namespace, svc.Name, job.(runtime.Object))
 				if err != nil {
 					return err
 				}
@@ -280,7 +319,7 @@ func (jc *JobController) CreateNewService(job metav1.Object, rtype apiv1.Replica
 	// Create OwnerReference.
 	controllerRef := jc.GenOwnerReference(job)
 
-	err = jc.CreateServicesWithControllerRef(job.GetNamespace(), service, job.(runtime.Object), controllerRef)
+	err = jc.ServiceControl.CreateServicesWithControllerRef(job.GetNamespace(), service, job.(runtime.Object), controllerRef)
 	if err != nil && errors.IsTimeout(err) {
 		// Service is created but its initialization has timed out.
 		// If the initialization is successful eventually, the
@@ -293,42 +332,5 @@ func (jc *JobController) CreateNewService(job metav1.Object, rtype apiv1.Replica
 	} else if err != nil {
 		return err
 	}
-	return nil
-}
-
-func (jc *JobController) CreateServicesWithControllerRef(namespace string, service *v1.Service, controllerObject runtime.Object, controllerRef *metav1.OwnerReference) error {
-	if err := control.ValidateControllerRef(controllerRef); err != nil {
-		return err
-	}
-	return jc.createServices(namespace, service, controllerObject, controllerRef)
-}
-
-func (jc *JobController) createServices(namespace string, service *v1.Service, object runtime.Object, controllerRef *metav1.OwnerReference) error {
-	if labels.Set(service.Labels).AsSelectorPreValidated().Empty() {
-		return fmt.Errorf("unable to create Services, no labels")
-	}
-	serviceWithOwner, err := control.GetServiceFromTemplate(service, object, controllerRef)
-	serviceWithOwner.Namespace = namespace
-	if err != nil {
-		jc.Recorder.Eventf(object, v1.EventTypeWarning, control.FailedCreateServiceReason, "Error creating: %v", err)
-		failedServiceCreationCount.Inc()
-		return fmt.Errorf("unable to create services: %v", err)
-	}
-
-	err = jc.Controller.CreateService(object, serviceWithOwner)
-	if err != nil {
-		jc.Recorder.Eventf(object, v1.EventTypeWarning, control.FailedCreateServiceReason, "Error creating: %v", err)
-		failedServiceCreationCount.Inc()
-		return fmt.Errorf("unable to create services: %v", err)
-	}
-
-	accessor, err := meta.Accessor(object)
-	if err != nil {
-		log.Errorf("parentObject does not have ObjectMeta, %v", err)
-		return nil
-	}
-	log.Infof("Controller %v created service %v", accessor.GetName(), serviceWithOwner.Name)
-	jc.Recorder.Eventf(object, v1.EventTypeNormal, control.SuccessfulCreateServiceReason, "Created service: %v", serviceWithOwner.Name)
-	succeededServiceCreationCount.Inc()
 	return nil
 }

--- a/test_job/controller.v1/test_job/test_job_controller.go
+++ b/test_job/controller.v1/test_job/test_job_controller.go
@@ -41,10 +41,6 @@ func (TestJobController) GetDefaultContainerPortName() string {
 	return "default-port-name"
 }
 
-func (TestJobController) GetDefaultContainerPortNumber() int32 {
-	return int32(9999)
-}
-
 func (t *TestJobController) GetJobFromInformerCache(namespace, name string) (metav1.Object, error) {
 	return t.Job, nil
 }

--- a/test_job/controller.v1/test_job/test_job_controller.go
+++ b/test_job/controller.v1/test_job/test_job_controller.go
@@ -17,14 +17,6 @@ type TestJobController struct {
 	Services []*corev1.Service
 }
 
-func (t TestJobController) GetPodsForJob(job interface{}) ([]*corev1.Pod, error) {
-	return []*corev1.Pod{}, nil
-}
-
-func (t TestJobController) GetServicesForJob(job interface{}) ([]*corev1.Service, error) {
-	return []*corev1.Service{}, nil
-}
-
 func (TestJobController) ControllerName() string {
 	return "test-operator"
 }
@@ -73,38 +65,6 @@ func (t *TestJobController) UpdateJobStatus(job interface{}, replicas map[common
 }
 
 func (t *TestJobController) UpdateJobStatusInApiServer(job interface{}, jobStatus *commonv1.JobStatus) error {
-	return nil
-}
-
-func (t *TestJobController) CreateService(job interface{}, service *corev1.Service) error {
-	return nil
-}
-
-func (t *TestJobController) DeleteService(job interface{}, name string, namespace string) error {
-	log.Info("Deleting service " + name)
-	var remainingServices []*corev1.Service
-	for _, tservice := range t.Services {
-		if tservice.Name != name {
-			remainingServices = append(remainingServices, tservice)
-		}
-	}
-	t.Services = remainingServices
-	return nil
-}
-
-func (t *TestJobController) CreatePod(job interface{}, pod *corev1.Pod) error {
-	return nil
-}
-
-func (t *TestJobController) DeletePod(job interface{}, pod *corev1.Pod) error {
-	log.Info("Deleting pod " + pod.Name)
-	var remainingPods []*corev1.Pod
-	for _, tpod := range t.Pods {
-		if tpod.Name != pod.Name {
-			remainingPods = append(remainingPods, tpod)
-		}
-	}
-	t.Pods = remainingPods
 	return nil
 }
 


### PR DESCRIPTION
The motivation of this PR is to reduce the efforts to build a training job operators. 

1. These are all common CRUD operations and there's no big difference between job operators. We don't have to expose to external for implementation. Instead, this should be inside common libraries or inbuilt controller methods user should not take care of. 

```
GetPodsForJob
GetServiceForJob
CreateService
DeleteService
CreatePod
DeletePod
```

As we bring back control and expectation packages, we have enough utils to implement these methods easily inside `JobController`. 


2. `GetDefaultContainerPortNumber()` is an interface never been used, we reply on `GetDefaultContainerName()` and `GetDefaultContainerPortName ()` to find the port, this is expose to user to make the decision. I think it was brought into interface but not well designed.. We remove it for now. 