### PR TITLE
Provides more flexibility for customizations

### DIFF
--- a/pkg/apis/common/v1/interface.go
+++ b/pkg/apis/common/v1/interface.go
@@ -26,6 +26,14 @@ type ControllerInterface interface {
 	// Returns the Job from API server
 	GetJobFromAPIClient(namespace, name string) (metav1.Object, error)
 
+	// GetPodsForJob returns the pods managed by the job. This can be achieved by selecting pods using label key "job-name"
+	// i.e. all pods created by the job will come with label "job-name" = <this_job_name>
+	GetPodsForJob(job interface{}) ([]*v1.Pod, error)
+
+	// GetServicesForJob returns the services managed by the job. This can be achieved by selecting services using label key "job-name"
+	// i.e. all services created by the job will come with label "job-name" = <this_job_name>
+	GetServicesForJob(job interface{}) ([]*v1.Service, error)
+
 	// DeleteJob deletes the job
 	DeleteJob(job interface{}) error
 

--- a/pkg/apis/common/v1/interface.go
+++ b/pkg/apis/common/v1/interface.go
@@ -47,4 +47,19 @@ type ControllerInterface interface {
 	// Returns if this replica type with index specified is a master role.
 	// MasterRole pod will have "job-role=master" set in its label
 	IsMasterRole(replicas map[ReplicaType]*ReplicaSpec, rtype ReplicaType, index int) bool
+
+	// ReconcileJobs checks and updates replicas for each given ReplicaSpec of a job.
+	// Common implementation will be provided and User can still override this to implement their own reconcile logic
+	ReconcileJobs(job interface{}, replicas map[ReplicaType]*ReplicaSpec, jobStatus JobStatus, runPolicy *RunPolicy) error
+
+	// ReconcilePods checks and updates pods for each given ReplicaSpec.
+	// It will requeue the job in case of an error while creating/deleting pods.
+	// Common implementation will be provided and User can still override this to implement their own reconcile logic
+	ReconcilePods(job interface{}, jobStatus *JobStatus, pods []*v1.Pod, rtype ReplicaType, spec *ReplicaSpec,
+		replicas map[ReplicaType]*ReplicaSpec) error
+
+	// ReconcileServices checks and updates services for each given ReplicaSpec.
+	// It will requeue the job in case of an error while creating/deleting services.
+	// Common implementation will be provided and User can still override this to implement their own reconcile logic
+	ReconcileServices(job metav1.Object, services []*v1.Service, rtype ReplicaType, spec *ReplicaSpec) error
 }

--- a/pkg/controller.v1/common/job.go
+++ b/pkg/controller.v1/common/job.go
@@ -93,14 +93,13 @@ func (jc *JobController) ReconcileJobs(
 
 	oldStatus := jobStatus.DeepCopy()
 
-	pods, err := jc.GetPodsForJob(job)
+	pods, err := jc.Controller.GetPodsForJob(job)
 	if err != nil {
 		log.Warnf("GetPodsForJob error %v", err)
 		return err
 	}
 
-	services, err := jc.GetServicesForJob(job)
-
+	services, err := jc.Controller.GetServicesForJob(job)
 	if err != nil {
 		log.Warnf("GetServicesForJob error %v", err)
 		return err

--- a/pkg/controller.v1/common/job_test.go
+++ b/pkg/controller.v1/common/job_test.go
@@ -65,7 +65,7 @@ func TestDeletePodsAndServices(T *testing.T) {
 		}
 
 		job := &testjobv1.TestJob{}
-		err := mainJobController.deletePodsAndServices(&runPolicy, job, allPods)
+		err := mainJobController.DeletePodsAndServices(&runPolicy, job, allPods)
 
 		if assert.NoError(T, err) {
 			if tc.deleteRunningPodAndService {
@@ -120,7 +120,7 @@ func TestPastBackoffLimit(T *testing.T) {
 			BackoffLimit: &tc.backOffLimit,
 		}
 
-		result, err := mainJobController.pastBackoffLimit("fake-job", &runPolicy, nil, allPods)
+		result, err := mainJobController.PastBackoffLimit("fake-job", &runPolicy, nil, allPods)
 
 		if assert.NoError(T, err) {
 			assert.Equal(T, result, tc.shouldPassBackoffLimit)
@@ -161,7 +161,7 @@ func TestPastActiveDeadline(T *testing.T) {
 			},
 		}
 
-		result := mainJobController.pastActiveDeadline(&runPolicy, jobStatus)
+		result := mainJobController.PastActiveDeadline(&runPolicy, jobStatus)
 		assert.Equal(
 			T, result, tc.shouldPassActiveDeadline,
 			"Result is not expected for activeDeadlineSeconds == "+strconv.FormatInt(tc.activeDeadlineSeconds, 10))
@@ -216,7 +216,7 @@ func TestCleanupJob(T *testing.T) {
 	}
 
 	var job interface{}
-	err := mainJobController.cleanupJob(&runPolicy, jobStatus, job)
+	err := mainJobController.CleanupJob(&runPolicy, jobStatus, job)
 	if assert.NoError(T, err) {
 		assert.Empty(T, testJobController.Job)
 	}

--- a/test_job/controller.v1/test_job/test_job_controller.go
+++ b/test_job/controller.v1/test_job/test_job_controller.go
@@ -12,6 +12,7 @@ import (
 var _ commonv1.ControllerInterface = &TestJobController{}
 
 type TestJobController struct {
+	commonv1.ControllerInterface
 	Job      *v1.TestJob
 	Pods     []*corev1.Pod
 	Services []*corev1.Service


### PR DESCRIPTION
Following methods both have common implementation and user can override them if existing solution doesn't fit. 

1. Add `GetPodsForJob` and `GetServiceForJob` back for kubebuilder based operator.
2. Add `ReconcileJobs`, `ReconcilePods` and `ReconcileServices` into interface. 
3. Expose methods for better customization

This has been tested with mxnet-operator (built with low level informer and lister) and xgboost-operator (built with kubebuilder)


Seems tensorflow operator may have some customizations on reconcile logic, they can override the  methods and still leverage some common methods.