### PR TITLE
Skip some logics for terminated job and add PodGroup reconcile loop

### DIFF
--- a/pkg/controller.v1/common/job.go
+++ b/pkg/controller.v1/common/job.go
@@ -214,6 +214,14 @@ func (jc *JobController) ReconcileJobs(
 		return jc.Controller.UpdateJobStatusInApiServer(job, &jobStatus)
 	} else {
 		// General cases which need to reconcile
+		if jc.Config.EnableGangScheduling {
+			minAvailableReplicas := totalReplicas
+			_, err := jc.SyncPodGroup(metaObject, minAvailableReplicas)
+			if err != nil {
+				log.Warnf("Sync PodGroup %v: %v", jobKey, err)
+			}
+		}
+
 		// Diff current active pods/services with replicas.
 		for rtype, spec := range replicas {
 			err := jc.Controller.ReconcilePods(metaObject, &jobStatus, pods, rtype, spec, replicas)


### PR DESCRIPTION
Resolve #92 #94

1. Skip checking activeDeadline or backoffLimit if job terminated 
2. Add PodGroup reconcile logic
