### PR TITLE
Make ports more flexiable for customizations

### DIFF
--- a/pkg/controller.v1/common/service.go
+++ b/pkg/controller.v1/common/service.go
@@ -25,7 +25,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -252,24 +252,24 @@ func (jc *JobController) ReconcileServices(
 	return nil
 }
 
-// GetPortFromJob gets the port of job container. Port could be nil depending on different distributed communication strategy
-func (jc *JobController) GetPortFromJob(spec *apiv1.ReplicaSpec) (*int32, error) {
-	// Consider the case controller doesn't use fixed port, headless service without port will enable random pod to pod communication
-	if jc.Controller.GetDefaultContainerPortName() == "" {
-		return nil, nil
-	}
+// GetPortsFromJob gets the ports of job container. Port could be nil, if distributed communication strategy doesn't need and no other ports that need to be exposed.
+func (jc *JobController) GetPortsFromJob(spec *apiv1.ReplicaSpec) (*map[string]int32, error) {
+	ports := make(map[string]int32)
 
 	containers := spec.Template.Spec.Containers
 	for _, container := range containers {
 		if container.Name == jc.Controller.GetDefaultContainerName() {
-			ports := container.Ports
-			for _, port := range ports {
-				if port.Name == jc.Controller.GetDefaultContainerPortName() {
-					return &port.ContainerPort, nil
-				}
+			containerPorts := container.Ports
+			if len(containerPorts) == 0 {
+				return nil, nil
 			}
+			for _, port := range containerPorts {
+				ports[port.Name] = port.ContainerPort
+			}
+			return &ports, nil
 		}
 	}
+
 	return nil, fmt.Errorf("failed to find the port")
 }
 
@@ -295,7 +295,7 @@ func (jc *JobController) CreateNewService(job metav1.Object, rtype apiv1.Replica
 	labels[apiv1.ReplicaTypeLabel] = rt
 	labels[apiv1.ReplicaIndexLabel] = index
 
-	port, err := jc.GetPortFromJob(spec)
+	ports, err := jc.GetPortsFromJob(spec)
 	if err != nil {
 		return err
 	}
@@ -308,10 +308,12 @@ func (jc *JobController) CreateNewService(job metav1.Object, rtype apiv1.Replica
 		},
 	}
 
-	// Add service port to headless service only if port is set from controller implementation
-	if port != nil {
-		svcPort := v1.ServicePort{Name: jc.Controller.GetDefaultContainerPortName(), Port: *port}
-		service.Spec.Ports = append(service.Spec.Ports, svcPort)
+	// Add service ports to headless service
+	if ports != nil {
+		for name, port := range *ports {
+			svcPort := v1.ServicePort{Name: name, Port: port}
+			service.Spec.Ports = append(service.Spec.Ports, svcPort)
+		}
 	}
 
 	service.Name = GenGeneralName(job.GetName(), rt, index)

--- a/pkg/controller.v1/common/service.go
+++ b/pkg/controller.v1/common/service.go
@@ -309,11 +309,9 @@ func (jc *JobController) CreateNewService(job metav1.Object, rtype apiv1.Replica
 	}
 
 	// Add service ports to headless service
-	if ports != nil {
-		for name, port := range ports {
-			svcPort := v1.ServicePort{Name: name, Port: port}
-			service.Spec.Ports = append(service.Spec.Ports, svcPort)
-		}
+	for name, port := range ports {
+		svcPort := v1.ServicePort{Name: name, Port: port}
+		service.Spec.Ports = append(service.Spec.Ports, svcPort)
 	}
 
 	service.Name = GenGeneralName(job.GetName(), rt, index)

--- a/pkg/controller.v1/common/service.go
+++ b/pkg/controller.v1/common/service.go
@@ -253,7 +253,7 @@ func (jc *JobController) ReconcileServices(
 }
 
 // GetPortsFromJob gets the ports of job container. Port could be nil, if distributed communication strategy doesn't need and no other ports that need to be exposed.
-func (jc *JobController) GetPortsFromJob(spec *apiv1.ReplicaSpec) (*map[string]int32, error) {
+func (jc *JobController) GetPortsFromJob(spec *apiv1.ReplicaSpec) (map[string]int32, error) {
 	ports := make(map[string]int32)
 
 	containers := spec.Template.Spec.Containers
@@ -266,7 +266,7 @@ func (jc *JobController) GetPortsFromJob(spec *apiv1.ReplicaSpec) (*map[string]i
 			for _, port := range containerPorts {
 				ports[port.Name] = port.ContainerPort
 			}
-			return &ports, nil
+			return ports, nil
 		}
 	}
 
@@ -310,7 +310,7 @@ func (jc *JobController) CreateNewService(job metav1.Object, rtype apiv1.Replica
 
 	// Add service ports to headless service
 	if ports != nil {
-		for name, port := range *ports {
+		for name, port := range ports {
 			svcPort := v1.ServicePort{Name: name, Port: port}
 			service.Spec.Ports = append(service.Spec.Ports, svcPort)
 		}

--- a/pkg/controller.v1/common/service_test.go
+++ b/pkg/controller.v1/common/service_test.go
@@ -4,9 +4,21 @@ import (
 	"testing"
 
 	apiv1 "github.com/kubeflow/common/pkg/apis/common/v1"
+	"github.com/kubeflow/common/pkg/controller.v1/control"
+	"github.com/kubeflow/common/pkg/controller.v1/expectation"
+	testjobv1 "github.com/kubeflow/common/test_job/apis/test_job/v1"
+	testjob "github.com/kubeflow/common/test_job/controller.v1/test_job"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	schedulinglisters "k8s.io/client-go/listers/scheduling/v1beta1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	volcanoclient "volcano.sh/apis/pkg/client/clientset/versioned"
 )
 
 func TestCalculateServiceSliceSize(t *testing.T) {
@@ -64,5 +76,135 @@ func TestCalculateServiceSliceSize(t *testing.T) {
 	for _, tc := range testCases {
 		result := calculateServiceSliceSize(tc.services, tc.replicas)
 		assert.Equal(t, tc.expectedSize, result)
+	}
+}
+
+func TestJobController_CreateNewService(t *testing.T) {
+	type fields struct {
+		Controller                  apiv1.ControllerInterface
+		Config                      JobControllerConfiguration
+		PodControl                  control.PodControlInterface
+		ServiceControl              control.ServiceControlInterface
+		KubeClientSet               kubeclientset.Interface
+		VolcanoClientSet            volcanoclient.Interface
+		PodLister                   corelisters.PodLister
+		ServiceLister               corelisters.ServiceLister
+		PriorityClassLister         schedulinglisters.PriorityClassLister
+		PodInformerSynced           cache.InformerSynced
+		ServiceInformerSynced       cache.InformerSynced
+		PriorityClassInformerSynced cache.InformerSynced
+		Expectations                expectation.ControllerExpectationsInterface
+		WorkQueue                   workqueue.RateLimitingInterface
+		Recorder                    record.EventRecorder
+	}
+	type args struct {
+		job   metav1.Object
+		rtype apiv1.ReplicaType
+		spec  *apiv1.ReplicaSpec
+		index string
+	}
+
+	var replicas int32
+	replicas = 2
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{name: "test0",
+			fields: fields{
+				Controller:     &testjob.TestJobController{},
+				Expectations:   expectation.NewControllerExpectations(),
+				ServiceControl: &control.FakeServiceControl{},
+			},
+			args: args{
+				job:   &testjobv1.TestJob{},
+				rtype: "Worker",
+				spec: &apiv1.ReplicaSpec{
+					Replicas: &replicas,
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								v1.Container{
+									Name: "default-container",
+									Ports: []v1.ContainerPort{
+										v1.ContainerPort{
+											Name:          "test",
+											ContainerPort: 8080,
+										},
+										v1.ContainerPort{
+											Name:          "default-port-name",
+											ContainerPort: 2222,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				index: "0",
+			},
+			wantErr: false,
+		},
+		{name: "test1",
+			fields: fields{
+				Controller:     &testjob.TestJobController{},
+				Expectations:   expectation.NewControllerExpectations(),
+				ServiceControl: &control.FakeServiceControl{},
+			},
+			args: args{
+				job:   &testjobv1.TestJob{},
+				rtype: "Master",
+				spec: &apiv1.ReplicaSpec{
+					Replicas: &replicas,
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								v1.Container{
+									Name: "fake-container",
+									Ports: []v1.ContainerPort{
+										v1.ContainerPort{
+											Name:          "test",
+											ContainerPort: 8080,
+										},
+										v1.ContainerPort{
+											Name:          "default-port-name",
+											ContainerPort: 2222,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				index: "0",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jc := &JobController{
+				Controller:                  tt.fields.Controller,
+				Config:                      tt.fields.Config,
+				PodControl:                  tt.fields.PodControl,
+				ServiceControl:              tt.fields.ServiceControl,
+				KubeClientSet:               tt.fields.KubeClientSet,
+				VolcanoClientSet:            tt.fields.VolcanoClientSet,
+				PodLister:                   tt.fields.PodLister,
+				ServiceLister:               tt.fields.ServiceLister,
+				PriorityClassLister:         tt.fields.PriorityClassLister,
+				PodInformerSynced:           tt.fields.PodInformerSynced,
+				ServiceInformerSynced:       tt.fields.ServiceInformerSynced,
+				PriorityClassInformerSynced: tt.fields.PriorityClassInformerSynced,
+				Expectations:                tt.fields.Expectations,
+				WorkQueue:                   tt.fields.WorkQueue,
+				Recorder:                    tt.fields.Recorder,
+			}
+			if err := jc.CreateNewService(tt.args.job, tt.args.rtype, tt.args.spec, tt.args.index); (err != nil) != tt.wantErr {
+				t.Errorf("JobController.CreateNewService() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: xieydd chrisydxie@tencent.com
Try to resolve issue #122 .
This has been tested with tf-operator.
```
# tf-job
Worker:
  template:
    spec:
      ports:
      - name: test
        containerPort: 80

# worker svc
spec:
  clusterIP: None
  ports:
  - name: test
    port: 80
    protocol: TCP
    targetPort: 80
  - name: tfjob-port
    port: 2222
    protocol: TCP
    targetPort: 2222
  selector:
    group-name: kubeflow.org
    job-name: dist-mnist-for-e2e-test
    replica-index: "0"
    replica-type: ps
  sessionAffinity: None
  type: ClusterIP
```