### PR TITLE
fix: Add uppercase support for GenGeneralName

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+vendor/

--- a/pkg/controller.v1/common/util.go
+++ b/pkg/controller.v1/common/util.go
@@ -45,7 +45,7 @@ func (p ReplicasPriority) Swap(i, j int) {
 }
 
 func GenGeneralName(jobName string, rtype apiv1.ReplicaType, index string) string {
-	n := jobName + "-" + string(rtype) + "-" + index
+	n := jobName + "-" + strings.ToLower(string(rtype)) + "-" + index
 	return strings.Replace(n, "/", "-", -1)
 }
 

--- a/pkg/controller.v1/common/util_test.go
+++ b/pkg/controller.v1/common/util_test.go
@@ -15,21 +15,39 @@
 package common
 
 import (
-	"fmt"
-	apiv1 "github.com/kubeflow/common/pkg/apis/common/v1"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	apiv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 )
 
 func TestGenGeneralName(t *testing.T) {
-	var testRType apiv1.ReplicaType = "worker"
-	testIndex := "1"
-	testKey := "1/2/3/4/5"
-	expectedName := fmt.Sprintf("1-2-3-4-5-%s-%s", testRType, testIndex)
+	tcs := []struct {
+		index        string
+		key          string
+		replicaType  apiv1.ReplicaType
+		expectedName string
+	}{
+		{
+			index:        "1",
+			key:          "1/2/3/4/5",
+			replicaType:  "worker",
+			expectedName: "1-2-3-4-5-worker-1",
+		},
+		{
+			index:        "1",
+			key:          "1/2/3/4/5",
+			replicaType:  "WORKER",
+			expectedName: "1-2-3-4-5-worker-1",
+		},
+	}
 
-	name := GenGeneralName(testKey, testRType, testIndex)
-	if name != expectedName {
-		t.Errorf("Expected name %s, got %s", expectedName, name)
+	for _, tc := range tcs {
+		actual := GenGeneralName(tc.key, tc.replicaType, tc.index)
+		if actual != tc.expectedName {
+			t.Errorf("Expected name %s, got %s", tc.expectedName, actual)
+		}
 	}
 }
 


### PR DESCRIPTION
In GenGeneralName, we should use lower case.

In the past we do the conversion outside the function since the replicaType is a string. Now its type is replicaType, thus we should do it in the function.

/cc @terrytangyuan @MartinForReal 

Signed-off-by: cegao <cegao@tencent.com>