### PR TITLE
fix replicaType key for filtering pods and services

### DIFF
--- a/pkg/controller.v1/common/pod.go
+++ b/pkg/controller.v1/common/pod.go
@@ -258,7 +258,7 @@ func (jc *JobController) FilterPodsForReplicaType(pods []*v1.Pod, replicaType ap
 	var result []*v1.Pod
 
 	selector := labels.SelectorFromValidatedSet(labels.Set{
-		apiv1.ReplicaIndexLabel: string(replicaType),
+		apiv1.ReplicaTypeLabel: string(replicaType),
 	})
 
 	// TODO(#149): Remove deprecated selector.

--- a/pkg/controller.v1/common/service.go
+++ b/pkg/controller.v1/common/service.go
@@ -142,7 +142,7 @@ func (jc *JobController) FilterServicesForReplicaType(services []*v1.Service, re
 	var result []*v1.Service
 
 	selector := labels.SelectorFromValidatedSet(labels.Set{
-		apiv1.ReplicaIndexLabel: string(replicaType),
+		apiv1.ReplicaTypeLabel: string(replicaType),
 	})
 
 	// TODO(#149): Remove deprecated selector.


### PR DESCRIPTION
In #150, when updating the selector labels for matching services and pods, key `ReplicaIndexLabel` is introduced while I believe it needs `ReplicaTypeLabel`.