### PR TITLE
Use PriorityClassInterface instead of lister

### DIFF
--- a/pkg/controller.v1/common/job.go
+++ b/pkg/controller.v1/common/job.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sort"
@@ -424,7 +425,7 @@ func (jc *JobController) calcPGMinResources(minMember int32, replicas map[apiv1.
 		rp := ReplicaPriority{0, *replica}
 		pc := replica.Template.Spec.PriorityClassName
 
-		priorityClass, err := jc.PriorityClassLister.Get(pc)
+		priorityClass, err := jc.PriorityClassInterface.Get(context.Background(), pc, metav1.GetOptions{})
 		if err != nil || priorityClass == nil {
 			log.Warnf("Ignore task %s priority class %s: %v", t, pc, err)
 		} else {

--- a/pkg/controller.v1/common/job_controller.go
+++ b/pkg/controller.v1/common/job_controller.go
@@ -11,7 +11,7 @@ import (
 	kubeclientset "k8s.io/client-go/kubernetes"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
-	schedulinglisters "k8s.io/client-go/listers/scheduling/v1beta1"
+	schedulingv1 "k8s.io/client-go/kubernetes/typed/scheduling/v1"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -105,17 +105,14 @@ type JobController struct {
 	// ServiceLister can list/get services from the shared informer's store.
 	ServiceLister corelisters.ServiceLister
 
-	// PriorityClassLister can list/get priorityClasses from the shared informer's store.
-	PriorityClassLister schedulinglisters.PriorityClassLister
+	// PriorityClassInterface can list/get priorityClasses from the shared informer's store.
+	PriorityClassInterface schedulingv1.PriorityClassInterface
 
 	// PodInformerSynced returns true if the pod store has been synced at least once.
 	PodInformerSynced cache.InformerSynced
 
 	// ServiceInformerSynced returns true if the service store has been synced at least once.
 	ServiceInformerSynced cache.InformerSynced
-
-	// PriorityClassInformerSynced returns true if the priority class store has been synced at least once.
-	PriorityClassInformerSynced cache.InformerSynced
 
 	// A TTLCache of pod/services creates/deletes each job expects to see
 	// We use Job namespace/name + ReplicaType + pods/services as an expectation key,

--- a/pkg/controller.v1/common/service_test.go
+++ b/pkg/controller.v1/common/service_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	schedulingv1 "k8s.io/client-go/kubernetes/typed/scheduling/v1"
 	"testing"
 
 	apiv1 "github.com/kubeflow/common/pkg/apis/common/v1"
@@ -14,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclientset "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
-	schedulinglisters "k8s.io/client-go/listers/scheduling/v1beta1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -89,7 +89,7 @@ func TestJobController_CreateNewService(t *testing.T) {
 		VolcanoClientSet            volcanoclient.Interface
 		PodLister                   corelisters.PodLister
 		ServiceLister               corelisters.ServiceLister
-		PriorityClassLister         schedulinglisters.PriorityClassLister
+		PriorityClassInterface      schedulingv1.PriorityClassInterface
 		PodInformerSynced           cache.InformerSynced
 		ServiceInformerSynced       cache.InformerSynced
 		PriorityClassInformerSynced cache.InformerSynced
@@ -186,21 +186,20 @@ func TestJobController_CreateNewService(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			jc := &JobController{
-				Controller:                  tt.fields.Controller,
-				Config:                      tt.fields.Config,
-				PodControl:                  tt.fields.PodControl,
-				ServiceControl:              tt.fields.ServiceControl,
-				KubeClientSet:               tt.fields.KubeClientSet,
-				VolcanoClientSet:            tt.fields.VolcanoClientSet,
-				PodLister:                   tt.fields.PodLister,
-				ServiceLister:               tt.fields.ServiceLister,
-				PriorityClassLister:         tt.fields.PriorityClassLister,
-				PodInformerSynced:           tt.fields.PodInformerSynced,
-				ServiceInformerSynced:       tt.fields.ServiceInformerSynced,
-				PriorityClassInformerSynced: tt.fields.PriorityClassInformerSynced,
-				Expectations:                tt.fields.Expectations,
-				WorkQueue:                   tt.fields.WorkQueue,
-				Recorder:                    tt.fields.Recorder,
+				Controller:             tt.fields.Controller,
+				Config:                 tt.fields.Config,
+				PodControl:             tt.fields.PodControl,
+				ServiceControl:         tt.fields.ServiceControl,
+				KubeClientSet:          tt.fields.KubeClientSet,
+				VolcanoClientSet:       tt.fields.VolcanoClientSet,
+				PodLister:              tt.fields.PodLister,
+				ServiceLister:          tt.fields.ServiceLister,
+				PriorityClassInterface: tt.fields.PriorityClassInterface,
+				PodInformerSynced:      tt.fields.PodInformerSynced,
+				ServiceInformerSynced:  tt.fields.ServiceInformerSynced,
+				Expectations:           tt.fields.Expectations,
+				WorkQueue:              tt.fields.WorkQueue,
+				Recorder:               tt.fields.Recorder,
 			}
 			if err := jc.CreateNewService(tt.args.job, tt.args.rtype, tt.args.spec, tt.args.index); (err != nil) != tt.wantErr {
 				t.Errorf("JobController.CreateNewService() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Fix this issue in v0.3 branch

https://github.com/kubeflow/tf-operator/issues/1382

The major problem is we didn't initial `PriorityClassLister` after common migration. When it tries to create podGroup and calculate resources, it's panic. 


I've tested with tf-operator master. v1.2.0 should be fixed same way

/cc @kubeflow/wg-training-leads 