### PR TITLE
WIP: Revert #135: change rtype to commonv1.ReplicaType

### DIFF
--- a/pkg/apis/common/v1/interface.go
+++ b/pkg/apis/common/v1/interface.go
@@ -44,7 +44,7 @@ type ControllerInterface interface {
 	UpdateJobStatusInApiServer(job interface{}, jobStatus *JobStatus) error
 
 	// SetClusterSpec sets the cluster spec for the pod
-	SetClusterSpec(job interface{}, podTemplate *v1.PodTemplateSpec, rtype ReplicaType, index string) error
+	SetClusterSpec(job interface{}, podTemplate *v1.PodTemplateSpec, rtype, index string) error
 
 	// Returns the default container name in pod
 	GetDefaultContainerName() string

--- a/pkg/controller.v1/common/job.go
+++ b/pkg/controller.v1/common/job.go
@@ -3,6 +3,7 @@ package common
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	apiv1 "github.com/kubeflow/common/pkg/apis/common/v1"
@@ -300,9 +301,10 @@ func (jc *JobController) ReconcileJobs(
 // ResetExpectations reset the expectation for creates and deletes of pod/service to zero.
 func (jc *JobController) ResetExpectations(jobKey string, replicas map[apiv1.ReplicaType]*apiv1.ReplicaSpec) {
 	for rtype := range replicas {
-		expectationPodsKey := expectation.GenExpectationPodsKey(jobKey, rtype)
+		rt := strings.ToLower(string(rtype))
+		expectationPodsKey := expectation.GenExpectationPodsKey(jobKey, rt)
 		jc.Expectations.SetExpectations(expectationPodsKey, 0, 0)
-		expectationServicesKey := expectation.GenExpectationServicesKey(jobKey, rtype)
+		expectationServicesKey := expectation.GenExpectationServicesKey(jobKey, rt)
 		jc.Expectations.SetExpectations(expectationServicesKey, 0, 0)
 	}
 }

--- a/pkg/controller.v1/common/util.go
+++ b/pkg/controller.v1/common/util.go
@@ -47,8 +47,8 @@ func (p ReplicasPriority) Swap(i, j int) {
 	p[i], p[j] = p[j], p[i]
 }
 
-func GenGeneralName(jobName string, rtype apiv1.ReplicaType, index string) string {
-	n := jobName + "-" + strings.ToLower(string(rtype)) + "-" + index
+func GenGeneralName(jobName string, rtype, index string) string {
+	n := jobName + "-" + strings.ToLower(rtype) + "-" + index
 	return strings.Replace(n, "/", "-", -1)
 }
 

--- a/pkg/controller.v1/common/util_test.go
+++ b/pkg/controller.v1/common/util_test.go
@@ -18,15 +18,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	apiv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 )
 
 func TestGenGeneralName(t *testing.T) {
 	tcs := []struct {
 		index        string
 		key          string
-		replicaType  apiv1.ReplicaType
+		replicaType  string
 		expectedName string
 	}{
 		{

--- a/pkg/controller.v1/expectation/util.go
+++ b/pkg/controller.v1/expectation/util.go
@@ -1,16 +1,15 @@
 package expectation
 
 import (
-	apiv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 	"strings"
 )
 
 // GenExpectationPodsKey generates an expectation key for pods of a job
-func GenExpectationPodsKey(jobKey string, replicaType apiv1.ReplicaType) string {
-	return jobKey + "/" + strings.ToLower(string(replicaType)) + "/pods"
+func GenExpectationPodsKey(jobKey string, replicaType string) string {
+	return jobKey + "/" + strings.ToLower(replicaType) + "/pods"
 }
 
 // GenExpectationPodsKey generates an expectation key for services of a job
-func GenExpectationServicesKey(jobKey string, replicaType apiv1.ReplicaType) string {
-	return jobKey + "/" + strings.ToLower(string(replicaType)) + "/services"
+func GenExpectationServicesKey(jobKey string, replicaType string) string {
+	return jobKey + "/" + strings.ToLower(replicaType) + "/services"
 }

--- a/pkg/core/job.go
+++ b/pkg/core/job.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"sort"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -77,7 +78,7 @@ func PastActiveDeadline(runPolicy *apiv1.RunPolicy, jobStatus apiv1.JobStatus) b
 // this method applies only to pods with restartPolicy == OnFailure or Always
 func PastBackoffLimit(jobName string, runPolicy *apiv1.RunPolicy,
 	replicas map[apiv1.ReplicaType]*apiv1.ReplicaSpec, pods []*v1.Pod,
-	podFilterFunc func(pods []*v1.Pod, replicaType apiv1.ReplicaType) ([]*v1.Pod, error)) (bool, error) {
+	podFilterFunc func(pods []*v1.Pod, replicaType string) ([]*v1.Pod, error)) (bool, error) {
 	if runPolicy.BackoffLimit == nil {
 		return false, nil
 	}
@@ -88,7 +89,8 @@ func PastBackoffLimit(jobName string, runPolicy *apiv1.RunPolicy,
 			continue
 		}
 		// Convert ReplicaType to lower string.
-		pods, err := podFilterFunc(pods, rtype)
+		rt := strings.ToLower(string(rtype))
+		pods, err := podFilterFunc(pods, rt)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/core/pod.go
+++ b/pkg/core/pod.go
@@ -10,16 +10,16 @@ import (
 )
 
 // FilterPodsForReplicaType returns pods belong to a replicaType.
-func FilterPodsForReplicaType(pods []*v1.Pod, replicaType apiv1.ReplicaType) ([]*v1.Pod, error) {
+func FilterPodsForReplicaType(pods []*v1.Pod, replicaType string) ([]*v1.Pod, error) {
 	var result []*v1.Pod
 
 	selector := labels.SelectorFromValidatedSet(labels.Set{
-		apiv1.ReplicaTypeLabel: string(replicaType),
+		apiv1.ReplicaTypeLabel: replicaType,
 	})
 
 	// TODO(#149): Remove deprecated selector.
 	deprecatedSelector := labels.SelectorFromValidatedSet(labels.Set{
-		apiv1.ReplicaTypeLabelDeprecated: string(replicaType),
+		apiv1.ReplicaTypeLabelDeprecated: replicaType,
 	})
 
 	for _, pod := range pods {

--- a/pkg/core/service.go
+++ b/pkg/core/service.go
@@ -11,16 +11,16 @@ import (
 )
 
 // FilterServicesForReplicaType returns service belong to a replicaType.
-func FilterServicesForReplicaType(services []*v1.Service, replicaType apiv1.ReplicaType) ([]*v1.Service, error) {
+func FilterServicesForReplicaType(services []*v1.Service, replicaType string) ([]*v1.Service, error) {
 	var result []*v1.Service
 
 	selector := labels.SelectorFromValidatedSet(labels.Set{
-		apiv1.ReplicaTypeLabel: string(replicaType),
+		apiv1.ReplicaTypeLabel: replicaType,
 	})
 
 	// TODO(#149): Remove deprecated selector.
 	deprecatedSelector := labels.SelectorFromValidatedSet(labels.Set{
-		apiv1.ReplicaTypeLabelDeprecated: string(replicaType),
+		apiv1.ReplicaTypeLabelDeprecated: replicaType,
 	})
 
 	for _, service := range services {

--- a/pkg/core/utils.go
+++ b/pkg/core/utils.go
@@ -2,8 +2,6 @@ package core
 
 import (
 	"strings"
-
-	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 )
 
 func MaxInt(x, y int) int {
@@ -13,7 +11,7 @@ func MaxInt(x, y int) int {
 	return x
 }
 
-func GenGeneralName(jobName string, rtype commonv1.ReplicaType, index string) string {
-	n := jobName + "-" + strings.ToLower(string(rtype)) + "-" + index
+func GenGeneralName(jobName string, rtype string, index string) string {
+	n := jobName + "-" + strings.ToLower(rtype) + "-" + index
 	return strings.Replace(n, "/", "-", -1)
 }

--- a/pkg/reconciler.v1/common/gang_volcano.go
+++ b/pkg/reconciler.v1/common/gang_volcano.go
@@ -165,12 +165,12 @@ func (r *VolcanoReconciler) ReconcilePodGroup(
 }
 
 // DecoratePodForGangScheduling decorates the podTemplate before it's used to generate a pod with information for gang-scheduling
-func (r *VolcanoReconciler) DecoratePodForGangScheduling(rtype commonv1.ReplicaType, podTemplate *corev1.PodTemplateSpec, job client.Object) {
+func (r *VolcanoReconciler) DecoratePodForGangScheduling(rt string, podTemplate *corev1.PodTemplateSpec, job client.Object) {
 	if podTemplate.Spec.SchedulerName == "" || podTemplate.Spec.SchedulerName == r.GetGangSchedulerName() {
 		podTemplate.Spec.SchedulerName = r.GetGangSchedulerName()
 	} else {
 		warnMsg := "Another scheduler is specified when gang-scheduling is enabled and it will not be overwritten"
-		commonutil.LoggerForReplica(job, rtype).Warn(warnMsg)
+		commonutil.LoggerForReplica(job, rt).Warn(warnMsg)
 		r.GetRecorder().Event(job, corev1.EventTypeWarning, "PodTemplateSchedulerNameAlreadySet", warnMsg)
 	}
 

--- a/pkg/reconciler.v1/common/interface.go
+++ b/pkg/reconciler.v1/common/interface.go
@@ -78,7 +78,7 @@ type GangSchedulingInterface interface {
 
 	// DecoratePodForGangScheduling SHOULD be overridden if gang scheduler demands Pods associated with PodGroup to be
 	// decorated with specific requests.
-	DecoratePodForGangScheduling(rtype commonv1.ReplicaType, podTemplate *corev1.PodTemplateSpec, job client.Object)
+	DecoratePodForGangScheduling(rtype string, podTemplate *corev1.PodTemplateSpec, job client.Object)
 }
 
 // PodInterface defines the abstract interface for Pod related actions, such like get, create or delete Pod
@@ -90,14 +90,14 @@ type PodInterface interface {
 	GetDefaultContainerName() string
 
 	// GenPodName CAN be overridden to customize Pod name.
-	GenPodName(jobName string, rtype commonv1.ReplicaType, index string) string
+	GenPodName(jobName string, rtype string, index string) string
 
 	// GetPodsForJob CAN be overridden to customize how to list all pods with the job.
 	GetPodsForJob(ctx context.Context, job client.Object) ([]*corev1.Pod, error)
 
 	// FilterPodsForReplicaType CAN be overridden if the linking approach between pods and replicaType changes as this
 	// function filters out pods for specific replica type from all pods associated with the job.
-	FilterPodsForReplicaType(pods []*corev1.Pod, replicaType commonv1.ReplicaType) ([]*corev1.Pod, error)
+	FilterPodsForReplicaType(pods []*corev1.Pod, replicaType string) ([]*corev1.Pod, error)
 
 	// GetPodSlices SHOULD NOT be overridden as it generates pod slices for further pod processing.
 	GetPodSlices(pods []*corev1.Pod, replicas int, logger *logrus.Entry) [][]*corev1.Pod
@@ -121,7 +121,7 @@ type PodInterface interface {
 
 	// DecoratePod CAN be overridden if customization to the pod is needed. The default implementation applies nothing
 	// to the pod.
-	DecoratePod(rtype commonv1.ReplicaType, podTemplate *corev1.PodTemplateSpec, job client.Object)
+	DecoratePod(rtype string, podTemplate *corev1.PodTemplateSpec, job client.Object)
 }
 
 // ServiceInterface defines the abstract interface for Pod related actions, such like get, create or delete Service
@@ -137,7 +137,7 @@ type ServiceInterface interface {
 
 	// FilterServicesForReplicaType CAN be overridden to customize how to filter out services for this Replica Type.
 	FilterServicesForReplicaType(services []*corev1.Service,
-		replicaType commonv1.ReplicaType) ([]*corev1.Service, error)
+		replicaType string) ([]*corev1.Service, error)
 
 	// GetServiceSlices CAN be overridden to customize how to generate service slices.
 	GetServiceSlices(services []*corev1.Service, replicas int, logger *logrus.Entry) [][]*corev1.Service
@@ -157,7 +157,7 @@ type ServiceInterface interface {
 	DeleteService(ns string, name string, job client.Object) error
 
 	// DecorateService CAN be overridden to customize this service right before being created
-	DecorateService(rtype commonv1.ReplicaType, svc *corev1.Service, job client.Object)
+	DecorateService(rtype string, svc *corev1.Service, job client.Object)
 }
 
 // JobInterface defines the abstract interface for Pod related actions, such like get, create or delete TFJob,

--- a/pkg/reconciler.v1/common/pod_test.go
+++ b/pkg/reconciler.v1/common/pod_test.go
@@ -15,6 +15,7 @@
 package common_test
 
 import (
+	"strings"
 	"testing"
 
 	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
@@ -30,7 +31,7 @@ import (
 func TestGenPodName(t *testing.T) {
 	type tc struct {
 		testJob      *testjobv1.TestJob
-		testRType    commonv1.ReplicaType
+		testRType    string
 		testIndex    string
 		expectedName string
 	}
@@ -40,7 +41,7 @@ func TestGenPodName(t *testing.T) {
 			tj.SetName("hello-world")
 			return tc{
 				testJob:      tj,
-				testRType:    commonv1.ReplicaType(testjobv1.TestReplicaTypeWorker),
+				testRType:    strings.ToLower(string(testjobv1.TestReplicaTypeWorker)),
 				testIndex:    "1",
 				expectedName: "hello-world-worker-1",
 			}
@@ -70,7 +71,7 @@ func PodInSlice(pod *corev1.Pod, pods []*corev1.Pod) bool {
 func TestFilterPodsForReplicaType(t *testing.T) {
 	type tc struct {
 		testPods     []*corev1.Pod
-		testRType    commonv1.ReplicaType
+		testRType    string
 		expectedPods []*corev1.Pod
 	}
 	testCase := []tc{
@@ -83,7 +84,7 @@ func TestFilterPodsForReplicaType(t *testing.T) {
 					Name:      "pod0",
 					Namespace: "default",
 					Labels: map[string]string{
-						commonv1.ReplicaTypeLabel: string(testjobv1.TestReplicaTypeMaster),
+						commonv1.ReplicaTypeLabel: strings.ToLower(string(testjobv1.TestReplicaTypeMaster)),
 					},
 				},
 				Spec:   corev1.PodSpec{},
@@ -95,7 +96,7 @@ func TestFilterPodsForReplicaType(t *testing.T) {
 					Name:      "pod1",
 					Namespace: "default",
 					Labels: map[string]string{
-						commonv1.ReplicaTypeLabel: string(testjobv1.TestReplicaTypeWorker),
+						commonv1.ReplicaTypeLabel: strings.ToLower(string(testjobv1.TestReplicaTypeWorker)),
 					},
 				},
 				Spec:   corev1.PodSpec{},
@@ -107,7 +108,7 @@ func TestFilterPodsForReplicaType(t *testing.T) {
 					Name:      "pod2",
 					Namespace: "default",
 					Labels: map[string]string{
-						commonv1.ReplicaTypeLabel: string(testjobv1.TestReplicaTypeWorker),
+						commonv1.ReplicaTypeLabel: strings.ToLower(string(testjobv1.TestReplicaTypeWorker)),
 					},
 				},
 				Spec:   corev1.PodSpec{},
@@ -119,7 +120,7 @@ func TestFilterPodsForReplicaType(t *testing.T) {
 
 			return tc{
 				testPods:     allPods,
-				testRType:    commonv1.ReplicaType(testjobv1.TestReplicaTypeWorker),
+				testRType:    strings.ToLower(string(testjobv1.TestReplicaTypeWorker)),
 				expectedPods: filteredPods,
 			}
 		}(),

--- a/pkg/util/labels/labels.go
+++ b/pkg/util/labels/labels.go
@@ -16,9 +16,8 @@ package labels
 
 import (
 	"errors"
-	"strconv"
-
 	v1 "github.com/kubeflow/common/pkg/apis/common/v1"
+	"strconv"
 )
 
 // TODO(#149): Remove deprecated labels.
@@ -43,7 +42,7 @@ func SetReplicaIndexStr(labels map[string]string, idx string) {
 	labels[v1.ReplicaIndexLabelDeprecated] = idx
 }
 
-func ReplicaType(labels map[string]string) (v1.ReplicaType, error) {
+func ReplicaType(labels map[string]string) (string, error) {
 	v, ok := labels[v1.ReplicaTypeLabel]
 	if !ok {
 		v, ok = labels[v1.ReplicaTypeLabelDeprecated]
@@ -51,12 +50,12 @@ func ReplicaType(labels map[string]string) (v1.ReplicaType, error) {
 			return "", errors.New("replica type label not found")
 		}
 	}
-	return v1.ReplicaType(v), nil
+	return v, nil
 }
 
-func SetReplicaType(labels map[string]string, rt v1.ReplicaType) {
-	labels[v1.ReplicaTypeLabel] = string(rt)
-	labels[v1.ReplicaTypeLabelDeprecated] = string(rt)
+func SetReplicaType(labels map[string]string, rt string) {
+	labels[v1.ReplicaTypeLabel] = rt
+	labels[v1.ReplicaTypeLabelDeprecated] = rt
 }
 
 func HasKnownLabels(labels map[string]string, groupName string) bool {

--- a/pkg/util/labels/labels_test.go
+++ b/pkg/util/labels/labels_test.go
@@ -52,7 +52,7 @@ func TestReplicaIndex(t *testing.T) {
 func TestReplicaType(t *testing.T) {
 	cases := map[string]struct {
 		labels  map[string]string
-		want    v1.ReplicaType
+		want    string
 		wantErr bool
 	}{
 		"new": {

--- a/pkg/util/logger.go
+++ b/pkg/util/logger.go
@@ -15,7 +15,6 @@
 package util
 
 import (
-	apiv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -24,7 +23,7 @@ import (
 	metav1unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func LoggerForReplica(job metav1.Object, rtype apiv1.ReplicaType) *log.Entry {
+func LoggerForReplica(job metav1.Object, rtype string) *log.Entry {
 	return log.WithFields(log.Fields{
 		// We use job to match the key used in controller.go
 		// Its more common in K8s to use a period to indicate namespace.name. So that's what we use.

--- a/test_job/controller.v1/test_job/test_job_controller.go
+++ b/test_job/controller.v1/test_job/test_job_controller.go
@@ -61,7 +61,7 @@ func (t *TestJobController) UpdateJobStatusInApiServer(job interface{}, jobStatu
 	return nil
 }
 
-func (t *TestJobController) SetClusterSpec(job interface{}, podTemplate *corev1.PodTemplateSpec, rtype commonv1.ReplicaType, index string) error {
+func (t *TestJobController) SetClusterSpec(job interface{}, podTemplate *corev1.PodTemplateSpec, rtype, index string) error {
 	return nil
 }
 


### PR DESCRIPTION
I filed this PR https://github.com/kubeflow/common/pull/158 against release-0.3 branch but didn't check in code against master at that time.  Please check details in #158 for the reason why I decide to revert this change.  

> A few things to note

1. Since CI was removed for unknown reason. I manually verify the code quality

```
➜  common git:(revert_135_new) ✗ go build ./...
➜  common git:(revert_135_new) ✗ go test ./...
?   	github.com/kubeflow/common/pkg/apis/common/v1	[no test files]
ok  	github.com/kubeflow/common/pkg/controller.v1/common	0.018s
ok  	github.com/kubeflow/common/pkg/controller.v1/control	0.028s
ok  	github.com/kubeflow/common/pkg/controller.v1/expectation	0.015s
?   	github.com/kubeflow/common/pkg/core	[no test files]
ok  	github.com/kubeflow/common/pkg/reconciler.v1/common	0.029s
ok  	github.com/kubeflow/common/pkg/util	0.018s
?   	github.com/kubeflow/common/pkg/util/k8sutil	[no test files]
ok  	github.com/kubeflow/common/pkg/util/labels	0.021s
?   	github.com/kubeflow/common/pkg/util/signals	[no test files]
ok  	github.com/kubeflow/common/pkg/util/train	0.014s
?   	github.com/kubeflow/common/test_job/apis/test_job/v1	[no test files]
?   	github.com/kubeflow/common/test_job/client/clientset/versioned	[no test files]
?   	github.com/kubeflow/common/test_job/client/clientset/versioned/fake	[no test files]
?   	github.com/kubeflow/common/test_job/client/clientset/versioned/scheme	[no test files]
?   	github.com/kubeflow/common/test_job/client/clientset/versioned/typed/test_job/v1	[no test files]
?   	github.com/kubeflow/common/test_job/client/clientset/versioned/typed/test_job/v1/fake	[no test files]
?   	github.com/kubeflow/common/test_job/client/informers/externalversions	[no test files]
?   	github.com/kubeflow/common/test_job/client/informers/externalversions/internalinterfaces	[no test files]
?   	github.com/kubeflow/common/test_job/client/informers/externalversions/test_job	[no test files]
?   	github.com/kubeflow/common/test_job/client/informers/externalversions/test_job/v1	[no test files]
?   	github.com/kubeflow/common/test_job/client/listers/test_job/v1	[no test files]
?   	github.com/kubeflow/common/test_job/controller.v1/test_job	[no test files]
?   	github.com/kubeflow/common/test_job/reconciler.v1/test_job	[no test files]
?   	github.com/kubeflow/common/test_job/test_util/v1	[no test files]
```

2. I will file a PR in training-operator repo to use this branch. It will build operator using this branch.
https://github.com/kubeflow/tf-operator/pull/1408

3. this change will unblock https://github.com/kubeflow/tf-operator/pull/1398


/cc @zw0610 @terrytangyuan @gaocegege 