### PR TITLE
Enforce backOffLimit in ExitCode restartPolicy

### DIFF
--- a/pkg/controller.v1/common/job.go
+++ b/pkg/controller.v1/common/job.go
@@ -313,7 +313,7 @@ func (jc *JobController) PastActiveDeadline(runPolicy *apiv1.RunPolicy, jobStatu
 }
 
 // PastBackoffLimit checks if container restartCounts sum exceeds BackoffLimit
-// this method applies only to pods with restartPolicy == OnFailure or Always
+// this method applies only to pods when restartPolicy is one of OnFailure, Always or ExitCode
 func (jc *JobController) PastBackoffLimit(jobName string, runPolicy *apiv1.RunPolicy,
 	replicas map[apiv1.ReplicaType]*apiv1.ReplicaSpec, pods []*v1.Pod) (bool, error) {
 	return core.PastBackoffLimit(jobName, runPolicy, replicas, pods, jc.FilterPodsForReplicaType)

--- a/pkg/core/job.go
+++ b/pkg/core/job.go
@@ -74,7 +74,7 @@ func PastActiveDeadline(runPolicy *apiv1.RunPolicy, jobStatus apiv1.JobStatus) b
 }
 
 // PastBackoffLimit checks if container restartCounts sum exceeds BackoffLimit
-// this method applies only to pods with restartPolicy == OnFailure or Always
+// this method applies only to pods when restartPolicy is one of OnFailure, Always or ExitCode
 func PastBackoffLimit(jobName string, runPolicy *apiv1.RunPolicy,
 	replicas map[apiv1.ReplicaType]*apiv1.ReplicaSpec, pods []*v1.Pod,
 	podFilterFunc func(pods []*v1.Pod, replicaType apiv1.ReplicaType) ([]*v1.Pod, error)) (bool, error) {
@@ -83,8 +83,8 @@ func PastBackoffLimit(jobName string, runPolicy *apiv1.RunPolicy,
 	}
 	result := int32(0)
 	for rtype, spec := range replicas {
-		if spec.RestartPolicy != apiv1.RestartPolicyOnFailure && spec.RestartPolicy != apiv1.RestartPolicyAlways {
-			log.Warnf("The restart policy of replica %v of the job %v is not OnFailure or Always. Not counted in backoff limit.", rtype, jobName)
+		if spec.RestartPolicy != apiv1.RestartPolicyOnFailure && spec.RestartPolicy != apiv1.RestartPolicyAlways && spec.RestartPolicy != apiv1.RestartPolicyExitCode {
+			log.Warnf("The restart policy of replica %v of the job %v is not OnFailure, Always or ExitCode. Not counted in backoff limit.", rtype, jobName)
 			continue
 		}
 		// Convert ReplicaType to lower string.


### PR DESCRIPTION
The `runPolicy.backOffLimit` allows one to specify the sum total of number of times pods are allowed to restart before giving up. This change allows the `backOffLimit` to be applied when the `restartPolicy` is set to `ExitCode`

closes #167