### PR TITLE
Fix openapi generate rule violation

### DIFF
--- a/pkg/apis/common/v1/openapi_generated.go
+++ b/pkg/apis/common/v1/openapi_generated.go
@@ -364,6 +364,11 @@ func schema_pkg_apis_common_v1_JobStatus(ref common.ReferenceCallback) common.Op
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"conditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "set",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Conditions is an array of current observed job conditions.",
 							Type:        []string{"array"},

--- a/pkg/apis/common/v1/types.go
+++ b/pkg/apis/common/v1/types.go
@@ -22,6 +22,7 @@ import (
 // +k8s:deepcopy-gen=true
 // JobStatus represents the current observed state of the training Job.
 type JobStatus struct {
+	// +listType=set
 	// Conditions is an array of current observed job conditions.
 	Conditions []JobCondition `json:"conditions"`
 


### PR DESCRIPTION
As mentioned in https://github.com/kubeflow/mpi-operator/pull/434#issuecomment-962420580

```
openapi-gen --input-dirs github.com/kubeflow/mpi-operator/v2/pkg/apis/kubeflow/v2beta1,github.com/kubeflow/common/pkg/apis/common/v1 --output-package github.com/kubeflow/mpi-operator/v2/pkg/apis/kubeflow/v2beta1 --go-header-file hack/boilerplate/boilerplate.go.txt
API rule violation: list_type_missing,github.com/kubeflow/common/pkg/apis/common/v1,JobStatus,Conditions
```

This PR fix this issue.