### PR TITLE
Revert ReplicaType to string

### DIFF
--- a/pkg/apis/common/v1/interface.go
+++ b/pkg/apis/common/v1/interface.go
@@ -1,7 +1,7 @@
 package v1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -44,7 +44,7 @@ type ControllerInterface interface {
 	UpdateJobStatusInApiServer(job interface{}, jobStatus *JobStatus) error
 
 	// SetClusterSpec sets the cluster spec for the pod
-	SetClusterSpec(job interface{}, podTemplate *v1.PodTemplateSpec, rtype ReplicaType, index string) error
+	SetClusterSpec(job interface{}, podTemplate *v1.PodTemplateSpec, rtype, index string) error
 
 	// Returns the default container name in pod
 	GetDefaultContainerName() string

--- a/pkg/controller.v1/common/job.go
+++ b/pkg/controller.v1/common/job.go
@@ -300,9 +300,9 @@ func (jc *JobController) ReconcileJobs(
 // ResetExpectations reset the expectation for creates and deletes of pod/service to zero.
 func (jc *JobController) ResetExpectations(jobKey string, replicas map[apiv1.ReplicaType]*apiv1.ReplicaSpec) {
 	for rtype := range replicas {
-		expectationPodsKey := expectation.GenExpectationPodsKey(jobKey, rtype)
+		expectationPodsKey := expectation.GenExpectationPodsKey(jobKey, string(rtype))
 		jc.Expectations.SetExpectations(expectationPodsKey, 0, 0)
-		expectationServicesKey := expectation.GenExpectationServicesKey(jobKey, rtype)
+		expectationServicesKey := expectation.GenExpectationServicesKey(jobKey, string(rtype))
 		jc.Expectations.SetExpectations(expectationServicesKey, 0, 0)
 	}
 }

--- a/pkg/controller.v1/common/service.go
+++ b/pkg/controller.v1/common/service.go
@@ -16,6 +16,7 @@ package common
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	apiv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 	"github.com/kubeflow/common/pkg/controller.v1/control"
@@ -74,7 +75,7 @@ func (jc *JobController) AddService(obj interface{}) {
 			return
 		}
 
-		expectationServicesKey := expectation.GenExpectationServicesKey(jobKey, rType)
+		expectationServicesKey := expectation.GenExpectationServicesKey(jobKey, string(rType))
 
 		jc.Expectations.CreationObserved(expectationServicesKey)
 		// TODO: we may need add backoff here
@@ -139,7 +140,7 @@ func (jc *JobController) GetServicesForJob(jobObject interface{}) ([]*v1.Service
 }
 
 // FilterServicesForReplicaType returns service belong to a replicaType.
-func (jc *JobController) FilterServicesForReplicaType(services []*v1.Service, replicaType apiv1.ReplicaType) ([]*v1.Service, error) {
+func (jc *JobController) FilterServicesForReplicaType(services []*v1.Service, replicaType string) ([]*v1.Service, error) {
 	return core.FilterServicesForReplicaType(services, replicaType)
 }
 
@@ -158,9 +159,11 @@ func (jc *JobController) ReconcileServices(
 	rtype apiv1.ReplicaType,
 	spec *apiv1.ReplicaSpec) error {
 
+	// Convert ReplicaType to lower string.
+	rt := strings.ToLower(string(rtype))
 	replicas := int(*spec.Replicas)
 	// Get all services for the type rt.
-	services, err := jc.FilterServicesForReplicaType(services, rtype)
+	services, err := jc.FilterServicesForReplicaType(services, rt)
 	if err != nil {
 		return err
 	}
@@ -171,13 +174,13 @@ func (jc *JobController) ReconcileServices(
 	// If replica is 4, return a slice with size 4. [[0],[1],[2],[]], a svc with replica-index 3 will be created.
 	//
 	// If replica is 1, return a slice with size 3. [[0],[1],[2]], svc with replica-index 1 and 2 are out of range and will be deleted.
-	serviceSlices := jc.GetServiceSlices(services, replicas, commonutil.LoggerForReplica(job, rtype))
+	serviceSlices := jc.GetServiceSlices(services, replicas, commonutil.LoggerForReplica(job, rt))
 
 	for index, serviceSlice := range serviceSlices {
 		if len(serviceSlice) > 1 {
-			commonutil.LoggerForReplica(job, rtype).Warningf("We have too many services for %s %d", rtype, index)
+			commonutil.LoggerForReplica(job, rt).Warningf("We have too many services for %s %d", rtype, index)
 		} else if len(serviceSlice) == 0 {
-			commonutil.LoggerForReplica(job, rtype).Infof("need to create new service: %s-%d", rtype, index)
+			commonutil.LoggerForReplica(job, rt).Infof("need to create new service: %s-%d", rtype, index)
 			err = jc.CreateNewService(job, rtype, spec, strconv.Itoa(index))
 			if err != nil {
 				return err
@@ -212,9 +215,10 @@ func (jc *JobController) CreateNewService(job metav1.Object, rtype apiv1.Replica
 		return err
 	}
 
+	rt := strings.ToLower(string(rtype))
 	// Append ReplicaTypeLabelDeprecated and ReplicaIndexLabelDeprecated labels.
 	labels := jc.GenLabels(job.GetName())
-	utillabels.SetReplicaType(labels, rtype)
+	utillabels.SetReplicaType(labels, rt)
 	utillabels.SetReplicaIndexStr(labels, index)
 
 	ports, err := jc.GetPortsFromJob(spec)
@@ -236,13 +240,13 @@ func (jc *JobController) CreateNewService(job metav1.Object, rtype apiv1.Replica
 		service.Spec.Ports = append(service.Spec.Ports, svcPort)
 	}
 
-	service.Name = GenGeneralName(job.GetName(), rtype, index)
+	service.Name = GenGeneralName(job.GetName(), rt, index)
 	service.Labels = labels
 	// Create OwnerReference.
 	controllerRef := jc.GenOwnerReference(job)
 
 	// Creation is expected when there is no error returned
-	expectationServicesKey := expectation.GenExpectationServicesKey(jobKey, rtype)
+	expectationServicesKey := expectation.GenExpectationServicesKey(jobKey, rt)
 	jc.Expectations.RaiseExpectations(expectationServicesKey, 1, 0)
 
 	err = jc.ServiceControl.CreateServicesWithControllerRef(job.GetNamespace(), service, job.(runtime.Object), controllerRef)

--- a/pkg/controller.v1/common/util.go
+++ b/pkg/controller.v1/common/util.go
@@ -47,8 +47,8 @@ func (p ReplicasPriority) Swap(i, j int) {
 	p[i], p[j] = p[j], p[i]
 }
 
-func GenGeneralName(jobName string, rtype apiv1.ReplicaType, index string) string {
-	n := jobName + "-" + strings.ToLower(string(rtype)) + "-" + index
+func GenGeneralName(jobName string, rtype string, index string) string {
+	n := jobName + "-" + strings.ToLower(rtype) + "-" + index
 	return strings.Replace(n, "/", "-", -1)
 }
 

--- a/pkg/controller.v1/common/util_test.go
+++ b/pkg/controller.v1/common/util_test.go
@@ -44,7 +44,7 @@ func TestGenGeneralName(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		actual := GenGeneralName(tc.key, tc.replicaType, tc.index)
+		actual := GenGeneralName(tc.key, string(tc.replicaType), tc.index)
 		if actual != tc.expectedName {
 			t.Errorf("Expected name %s, got %s", tc.expectedName, actual)
 		}

--- a/pkg/controller.v1/expectation/util.go
+++ b/pkg/controller.v1/expectation/util.go
@@ -1,16 +1,15 @@
 package expectation
 
 import (
-	apiv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 	"strings"
 )
 
 // GenExpectationPodsKey generates an expectation key for pods of a job
-func GenExpectationPodsKey(jobKey string, replicaType apiv1.ReplicaType) string {
-	return jobKey + "/" + strings.ToLower(string(replicaType)) + "/pods"
+func GenExpectationPodsKey(jobKey string, replicaType string) string {
+	return jobKey + "/" + strings.ToLower(replicaType) + "/pods"
 }
 
 // GenExpectationPodsKey generates an expectation key for services of a job
-func GenExpectationServicesKey(jobKey string, replicaType apiv1.ReplicaType) string {
-	return jobKey + "/" + strings.ToLower(string(replicaType)) + "/services"
+func GenExpectationServicesKey(jobKey string, replicaType string) string {
+	return jobKey + "/" + strings.ToLower(replicaType) + "/services"
 }

--- a/pkg/core/job.go
+++ b/pkg/core/job.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"sort"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -77,7 +78,7 @@ func PastActiveDeadline(runPolicy *apiv1.RunPolicy, jobStatus apiv1.JobStatus) b
 // this method applies only to pods when restartPolicy is one of OnFailure, Always or ExitCode
 func PastBackoffLimit(jobName string, runPolicy *apiv1.RunPolicy,
 	replicas map[apiv1.ReplicaType]*apiv1.ReplicaSpec, pods []*v1.Pod,
-	podFilterFunc func(pods []*v1.Pod, replicaType apiv1.ReplicaType) ([]*v1.Pod, error)) (bool, error) {
+	podFilterFunc func(pods []*v1.Pod, replicaType string) ([]*v1.Pod, error)) (bool, error) {
 	if runPolicy.BackoffLimit == nil {
 		return false, nil
 	}
@@ -88,7 +89,8 @@ func PastBackoffLimit(jobName string, runPolicy *apiv1.RunPolicy,
 			continue
 		}
 		// Convert ReplicaType to lower string.
-		pods, err := podFilterFunc(pods, rtype)
+		rt := strings.ToLower(string(rtype))
+		pods, err := podFilterFunc(pods, rt)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/core/pod.go
+++ b/pkg/core/pod.go
@@ -10,16 +10,16 @@ import (
 )
 
 // FilterPodsForReplicaType returns pods belong to a replicaType.
-func FilterPodsForReplicaType(pods []*v1.Pod, replicaType apiv1.ReplicaType) ([]*v1.Pod, error) {
+func FilterPodsForReplicaType(pods []*v1.Pod, replicaType string) ([]*v1.Pod, error) {
 	var result []*v1.Pod
 
 	selector := labels.SelectorFromValidatedSet(labels.Set{
-		apiv1.ReplicaTypeLabel: string(replicaType),
+		apiv1.ReplicaTypeLabel: replicaType,
 	})
 
 	// TODO(#149): Remove deprecated selector.
 	deprecatedSelector := labels.SelectorFromValidatedSet(labels.Set{
-		apiv1.ReplicaTypeLabelDeprecated: string(replicaType),
+		apiv1.ReplicaTypeLabelDeprecated: replicaType,
 	})
 
 	for _, pod := range pods {

--- a/pkg/core/service.go
+++ b/pkg/core/service.go
@@ -11,16 +11,16 @@ import (
 )
 
 // FilterServicesForReplicaType returns service belong to a replicaType.
-func FilterServicesForReplicaType(services []*v1.Service, replicaType apiv1.ReplicaType) ([]*v1.Service, error) {
+func FilterServicesForReplicaType(services []*v1.Service, replicaType string) ([]*v1.Service, error) {
 	var result []*v1.Service
 
 	selector := labels.SelectorFromValidatedSet(labels.Set{
-		apiv1.ReplicaTypeLabel: string(replicaType),
+		apiv1.ReplicaTypeLabel: replicaType,
 	})
 
 	// TODO(#149): Remove deprecated selector.
 	deprecatedSelector := labels.SelectorFromValidatedSet(labels.Set{
-		apiv1.ReplicaTypeLabelDeprecated: string(replicaType),
+		apiv1.ReplicaTypeLabelDeprecated: replicaType,
 	})
 
 	for _, service := range services {

--- a/pkg/core/utils.go
+++ b/pkg/core/utils.go
@@ -2,8 +2,6 @@ package core
 
 import (
 	"strings"
-
-	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 )
 
 func MaxInt(x, y int) int {
@@ -13,7 +11,7 @@ func MaxInt(x, y int) int {
 	return x
 }
 
-func GenGeneralName(jobName string, rtype commonv1.ReplicaType, index string) string {
-	n := jobName + "-" + strings.ToLower(string(rtype)) + "-" + index
+func GenGeneralName(jobName string, rtype string, index string) string {
+	n := jobName + "-" + strings.ToLower(rtype) + "-" + index
 	return strings.Replace(n, "/", "-", -1)
 }

--- a/pkg/reconciler.v1/common/gang_volcano.go
+++ b/pkg/reconciler.v1/common/gang_volcano.go
@@ -165,7 +165,7 @@ func (r *VolcanoReconciler) ReconcilePodGroup(
 }
 
 // DecoratePodForGangScheduling decorates the podTemplate before it's used to generate a pod with information for gang-scheduling
-func (r *VolcanoReconciler) DecoratePodForGangScheduling(rtype commonv1.ReplicaType, podTemplate *corev1.PodTemplateSpec, job client.Object) {
+func (r *VolcanoReconciler) DecoratePodForGangScheduling(rtype string, podTemplate *corev1.PodTemplateSpec, job client.Object) {
 	if podTemplate.Spec.SchedulerName == "" || podTemplate.Spec.SchedulerName == r.GetGangSchedulerName() {
 		podTemplate.Spec.SchedulerName = r.GetGangSchedulerName()
 	} else {

--- a/pkg/reconciler.v1/common/interface.go
+++ b/pkg/reconciler.v1/common/interface.go
@@ -78,7 +78,7 @@ type GangSchedulingInterface interface {
 
 	// DecoratePodForGangScheduling SHOULD be overridden if gang scheduler demands Pods associated with PodGroup to be
 	// decorated with specific requests.
-	DecoratePodForGangScheduling(rtype commonv1.ReplicaType, podTemplate *corev1.PodTemplateSpec, job client.Object)
+	DecoratePodForGangScheduling(rtype string, podTemplate *corev1.PodTemplateSpec, job client.Object)
 }
 
 // PodInterface defines the abstract interface for Pod related actions, such like get, create or delete Pod
@@ -90,14 +90,14 @@ type PodInterface interface {
 	GetDefaultContainerName() string
 
 	// GenPodName CAN be overridden to customize Pod name.
-	GenPodName(jobName string, rtype commonv1.ReplicaType, index string) string
+	GenPodName(jobName string, rtype string, index string) string
 
 	// GetPodsForJob CAN be overridden to customize how to list all pods with the job.
 	GetPodsForJob(ctx context.Context, job client.Object) ([]*corev1.Pod, error)
 
 	// FilterPodsForReplicaType CAN be overridden if the linking approach between pods and replicaType changes as this
 	// function filters out pods for specific replica type from all pods associated with the job.
-	FilterPodsForReplicaType(pods []*corev1.Pod, replicaType commonv1.ReplicaType) ([]*corev1.Pod, error)
+	FilterPodsForReplicaType(pods []*corev1.Pod, replicaType string) ([]*corev1.Pod, error)
 
 	// GetPodSlices SHOULD NOT be overridden as it generates pod slices for further pod processing.
 	GetPodSlices(pods []*corev1.Pod, replicas int, logger *logrus.Entry) [][]*corev1.Pod
@@ -113,7 +113,7 @@ type PodInterface interface {
 		replicas map[commonv1.ReplicaType]*commonv1.ReplicaSpec) error
 
 	// CreateNewPod CAN be overridden to customize how to create a new pod.
-	CreateNewPod(job client.Object, rt commonv1.ReplicaType, index string,
+	CreateNewPod(job client.Object, rt string, index string,
 		spec *commonv1.ReplicaSpec, masterRole bool, replicas map[commonv1.ReplicaType]*commonv1.ReplicaSpec) error
 
 	// DeletePod CAN be overridden to customize how to delete a pod of {name} in namespace {ns}.
@@ -121,7 +121,7 @@ type PodInterface interface {
 
 	// DecoratePod CAN be overridden if customization to the pod is needed. The default implementation applies nothing
 	// to the pod.
-	DecoratePod(rtype commonv1.ReplicaType, podTemplate *corev1.PodTemplateSpec, job client.Object)
+	DecoratePod(rtype string, podTemplate *corev1.PodTemplateSpec, job client.Object)
 }
 
 // ServiceInterface defines the abstract interface for Pod related actions, such like get, create or delete Service
@@ -136,8 +136,7 @@ type ServiceInterface interface {
 	GetServicesForJob(ctx context.Context, job client.Object) ([]*corev1.Service, error)
 
 	// FilterServicesForReplicaType CAN be overridden to customize how to filter out services for this Replica Type.
-	FilterServicesForReplicaType(services []*corev1.Service,
-		replicaType commonv1.ReplicaType) ([]*corev1.Service, error)
+	FilterServicesForReplicaType(services []*corev1.Service, replicaType string) ([]*corev1.Service, error)
 
 	// GetServiceSlices CAN be overridden to customize how to generate service slices.
 	GetServiceSlices(services []*corev1.Service, replicas int, logger *logrus.Entry) [][]*corev1.Service
@@ -157,7 +156,7 @@ type ServiceInterface interface {
 	DeleteService(ns string, name string, job client.Object) error
 
 	// DecorateService CAN be overridden to customize this service right before being created
-	DecorateService(rtype commonv1.ReplicaType, svc *corev1.Service, job client.Object)
+	DecorateService(rtype string, svc *corev1.Service, job client.Object)
 }
 
 // JobInterface defines the abstract interface for Pod related actions, such like get, create or delete TFJob,
@@ -222,7 +221,7 @@ type JobInterface interface {
 
 	// IsFlagReplicaTypeForJobStatus CAN be overridden to customize how to determine if this ReplicaType is the
 	// flag ReplicaType for the status of this kind of job
-	IsFlagReplicaTypeForJobStatus(rtype commonv1.ReplicaType) bool
+	IsFlagReplicaTypeForJobStatus(rtype string) bool
 
 	// IsJobSucceeded CAN be overridden to customize how to determine if this job is succeeded.
 	IsJobSucceeded(status commonv1.JobStatus) bool

--- a/pkg/reconciler.v1/common/job.go
+++ b/pkg/reconciler.v1/common/job.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"strings"
 	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 	"github.com/kubeflow/common/pkg/core"
@@ -306,7 +307,7 @@ func (r *KubeflowJobReconciler) UpdateJobStatus(
 		logrus.Infof("%s=%s, ReplicaType=%s expected=%d, running=%d, succeeded=%d , failed=%d",
 			jobKind, jobNamespacedName, rtype, expected, running, succeeded, failed)
 
-		if r.IsFlagReplicaTypeForJobStatus(rtype) {
+		if r.IsFlagReplicaTypeForJobStatus(string(rtype)) {
 			if running > 0 {
 				msg := fmt.Sprintf("%s %s is running.", jobKind, jobNamespacedName)
 				err := commonutil.UpdateJobConditions(jobStatus, commonv1.JobRunning, commonutil.JobRunningReason, msg)
@@ -447,7 +448,7 @@ func (r *KubeflowJobReconciler) CleanupJob(runPolicy *commonv1.RunPolicy, status
 }
 
 // IsFlagReplicaTypeForJobStatus checks if this replicaType is the flag replicaType for the status of KubeflowJob
-func (r *KubeflowJobReconciler) IsFlagReplicaTypeForJobStatus(rtype commonv1.ReplicaType) bool {
+func (r *KubeflowJobReconciler) IsFlagReplicaTypeForJobStatus(rtype string) bool {
 	logrus.Warnf(WarnDefaultImplementationTemplate, "IsFlagReplicaTypeForJobStatus")
 	return true
 }

--- a/pkg/reconciler.v1/common/pod_test.go
+++ b/pkg/reconciler.v1/common/pod_test.go
@@ -30,7 +30,7 @@ import (
 func TestGenPodName(t *testing.T) {
 	type tc struct {
 		testJob      *testjobv1.TestJob
-		testRType    commonv1.ReplicaType
+		testRType    string
 		testIndex    string
 		expectedName string
 	}
@@ -40,7 +40,7 @@ func TestGenPodName(t *testing.T) {
 			tj.SetName("hello-world")
 			return tc{
 				testJob:      tj,
-				testRType:    commonv1.ReplicaType(testjobv1.TestReplicaTypeWorker),
+				testRType:    string(testjobv1.TestReplicaTypeWorker),
 				testIndex:    "1",
 				expectedName: "hello-world-worker-1",
 			}
@@ -70,7 +70,7 @@ func PodInSlice(pod *corev1.Pod, pods []*corev1.Pod) bool {
 func TestFilterPodsForReplicaType(t *testing.T) {
 	type tc struct {
 		testPods     []*corev1.Pod
-		testRType    commonv1.ReplicaType
+		testRType    string
 		expectedPods []*corev1.Pod
 	}
 	testCase := []tc{
@@ -119,7 +119,7 @@ func TestFilterPodsForReplicaType(t *testing.T) {
 
 			return tc{
 				testPods:     allPods,
-				testRType:    commonv1.ReplicaType(testjobv1.TestReplicaTypeWorker),
+				testRType:    string(testjobv1.TestReplicaTypeWorker),
 				expectedPods: filteredPods,
 			}
 		}(),

--- a/pkg/reconciler.v1/common/service.go
+++ b/pkg/reconciler.v1/common/service.go
@@ -17,6 +17,7 @@ package common
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 	"github.com/kubeflow/common/pkg/core"
@@ -94,7 +95,7 @@ func (r *KubeflowServiceReconciler) GetServicesForJob(ctx context.Context, job c
 
 // FilterServicesForReplicaType returns service belong to a replicaType.
 func (r *KubeflowServiceReconciler) FilterServicesForReplicaType(services []*corev1.Service,
-	replicaType commonv1.ReplicaType) ([]*corev1.Service, error) {
+	replicaType string) ([]*corev1.Service, error) {
 	return core.FilterServicesForReplicaType(services, replicaType)
 }
 
@@ -110,9 +111,11 @@ func (r *KubeflowServiceReconciler) ReconcileServices(
 	rtype commonv1.ReplicaType,
 	spec *commonv1.ReplicaSpec) error {
 
+	// Convert ReplicaType to lower string.
+	rt := strings.ToLower(string(rtype))
 	replicas := int(*spec.Replicas)
 	// Get all services for the type rt.
-	services, err := r.FilterServicesForReplicaType(services, rtype)
+	services, err := r.FilterServicesForReplicaType(services, rt)
 	if err != nil {
 		return err
 	}
@@ -123,13 +126,13 @@ func (r *KubeflowServiceReconciler) ReconcileServices(
 	// If replica is 4, return a slice with size 4. [[0],[1],[2],[]], a svc with replica-index 3 will be created.
 	//
 	// If replica is 1, return a slice with size 3. [[0],[1],[2]], svc with replica-index 1 and 2 are out of range and will be deleted.
-	serviceSlices := r.GetServiceSlices(services, replicas, commonutil.LoggerForReplica(job, rtype))
+	serviceSlices := r.GetServiceSlices(services, replicas, commonutil.LoggerForReplica(job, rt))
 
 	for index, serviceSlice := range serviceSlices {
 		if len(serviceSlice) > 1 {
-			commonutil.LoggerForReplica(job, rtype).Warningf("We have too many services for %s %d", rtype, index)
+			commonutil.LoggerForReplica(job, rt).Warningf("We have too many services for %s %d", rtype, index)
 		} else if len(serviceSlice) == 0 {
-			commonutil.LoggerForReplica(job, rtype).Infof("need to create new service: %s-%d", rtype, index)
+			commonutil.LoggerForReplica(job, rt).Infof("need to create new service: %s-%d", rtype, index)
 			err = r.CreateNewService(job, rtype, spec, strconv.Itoa(index))
 			if err != nil {
 				return err
@@ -155,9 +158,11 @@ func (r *KubeflowServiceReconciler) ReconcileServices(
 func (r *KubeflowServiceReconciler) CreateNewService(job client.Object, rtype commonv1.ReplicaType,
 	spec *commonv1.ReplicaSpec, index string) error {
 
+	// Convert ReplicaType to lower string.
+	rt := strings.ToLower(string(rtype))
 	// Append ReplicaTypeLabel and ReplicaIndexLabel labels.
 	labels := r.GenLabels(job.GetName())
-	labels[commonv1.ReplicaTypeLabel] = string(rtype)
+	labels[commonv1.ReplicaTypeLabel] = rt
 	labels[commonv1.ReplicaIndexLabel] = index
 
 	ports, err := r.GetPortsFromJob(spec)
@@ -179,7 +184,7 @@ func (r *KubeflowServiceReconciler) CreateNewService(job client.Object, rtype co
 		service.Spec.Ports = append(service.Spec.Ports, svcPort)
 	}
 
-	service.Name = core.GenGeneralName(job.GetName(), rtype, index)
+	service.Name = core.GenGeneralName(job.GetName(), rt, index)
 	service.Namespace = job.GetNamespace()
 	service.Labels = labels
 	// Create OwnerReference.
@@ -188,7 +193,7 @@ func (r *KubeflowServiceReconciler) CreateNewService(job client.Object, rtype co
 		return err
 	}
 
-	r.DecorateService(rtype, service, job)
+	r.DecorateService(rt, service, job)
 
 	err = r.Create(context.Background(), service)
 	if err != nil && errors.IsTimeout(err) {
@@ -215,7 +220,7 @@ func (r *KubeflowServiceReconciler) DeleteService(ns string, name string, job cl
 }
 
 // DecorateService decorates the Service before it's submitted to APIServer
-func (r *KubeflowServiceReconciler) DecorateService(rtype commonv1.ReplicaType, svc *corev1.Service, job client.Object) {
+func (r *KubeflowServiceReconciler) DecorateService(rtype string, svc *corev1.Service, job client.Object) {
 	// Default implementation applies nothing to podTemplate
 	return
 }

--- a/pkg/reconciler.v1/common/service_test.go
+++ b/pkg/reconciler.v1/common/service_test.go
@@ -16,6 +16,7 @@ package common_test
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
@@ -60,7 +61,7 @@ func TestCreateNewService(t *testing.T) {
 						commonv1.OperatorNameLabel:        "Test Reconciler",
 						commonv1.JobNameLabelDeprecated:   jobName,
 						commonv1.JobNameLabel:             jobName,
-						commonv1.ReplicaTypeLabel:         string(testjobv1.TestReplicaTypeWorker),
+						commonv1.ReplicaTypeLabel:         strings.ToLower(string(testjobv1.TestReplicaTypeWorker)),
 						commonv1.ReplicaIndexLabel:        idx,
 					},
 				},

--- a/pkg/util/labels/labels.go
+++ b/pkg/util/labels/labels.go
@@ -54,9 +54,9 @@ func ReplicaType(labels map[string]string) (v1.ReplicaType, error) {
 	return v1.ReplicaType(v), nil
 }
 
-func SetReplicaType(labels map[string]string, rt v1.ReplicaType) {
-	labels[v1.ReplicaTypeLabel] = string(rt)
-	labels[v1.ReplicaTypeLabelDeprecated] = string(rt)
+func SetReplicaType(labels map[string]string, rt string) {
+	labels[v1.ReplicaTypeLabel] = rt
+	labels[v1.ReplicaTypeLabelDeprecated] = rt
 }
 
 func HasKnownLabels(labels map[string]string, groupName string) bool {

--- a/pkg/util/logger.go
+++ b/pkg/util/logger.go
@@ -15,16 +15,15 @@
 package util
 
 import (
-	apiv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func LoggerForReplica(job metav1.Object, rtype apiv1.ReplicaType) *log.Entry {
+func LoggerForReplica(job metav1.Object, rtype string) *log.Entry {
 	return log.WithFields(log.Fields{
 		// We use job to match the key used in controller.go
 		// Its more common in K8s to use a period to indicate namespace.name. So that's what we use.

--- a/test_job/controller.v1/test_job/test_job_controller.go
+++ b/test_job/controller.v1/test_job/test_job_controller.go
@@ -61,7 +61,7 @@ func (t *TestJobController) UpdateJobStatusInApiServer(job interface{}, jobStatu
 	return nil
 }
 
-func (t *TestJobController) SetClusterSpec(job interface{}, podTemplate *corev1.PodTemplateSpec, rtype commonv1.ReplicaType, index string) error {
+func (t *TestJobController) SetClusterSpec(job interface{}, podTemplate *corev1.PodTemplateSpec, rtype, index string) error {
 	return nil
 }
 


### PR DESCRIPTION
Since PR #163 has been stalled for a while, this pr tries to accomplish the same goal: revert rtype from `commonv1.ReplicaType` to `string`.

For any parameters, if it is of type `commonv1.ReplicaType`, it's reverted to `string` in this pr. However, parameters of type `map[commonv1.ReplicaType]{any_value_type}` remain unchanged.

@Jeffwan 