### PR TITLE
Support for PodGroup updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/go-logr/logr v1.2.3
+	github.com/google/go-cmp v0.5.8
 	github.com/prometheus/client_golang v1.12.2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.0
@@ -37,7 +38,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
-	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect

--- a/pkg/controller.v1/common/scheduling.go
+++ b/pkg/controller.v1/common/scheduling.go
@@ -28,6 +28,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -35,29 +36,34 @@ type FillPodGroupSpecFunc func(object metav1.Object) error
 
 func (jc *JobController) SyncPodGroup(job metav1.Object, specFunc FillPodGroupSpecFunc) (metav1.Object, error) {
 	pgctl := jc.PodGroupControl
+
 	// Check whether podGroup exists or not
 	podGroup, err := pgctl.GetPodGroup(job.GetNamespace(), job.GetName())
 	if err == nil {
-		return podGroup, nil
+		// update podGroup for gang scheduling
+		if err = specFunc(podGroup); err != nil {
+			return nil, fmt.Errorf("unable to fill the spec of PodGroup, '%v': %v", klog.KObj(podGroup), err)
+		}
+		return nil, pgctl.UpdatePodGroup(podGroup.(client.Object))
 	} else if client.IgnoreNotFound(err) != nil {
-		return nil, fmt.Errorf("unable to get PodGroup: %v", err)
-	}
+		return nil, fmt.Errorf("unable to get a PodGroup: %v", err)
+	} else {
+		// create podGroup for gang scheduling
+		newPodGroup := pgctl.NewEmptyPodGroup()
+		newPodGroup.SetName(job.GetName())
+		newPodGroup.SetNamespace(job.GetNamespace())
+		newPodGroup.SetAnnotations(job.GetAnnotations())
+		newPodGroup.SetOwnerReferences([]metav1.OwnerReference{*jc.GenOwnerReference(job)})
+		if err = specFunc(newPodGroup); err != nil {
+			return nil, fmt.Errorf("unable to fill the spec of PodGroup, '%v': %v", klog.KObj(newPodGroup), err)
+		}
 
-	// create podGroup for gang scheduling
-	toCreatePodGroup := pgctl.NewEmptyPodGroup()
-	toCreatePodGroup.SetName(job.GetName())
-	toCreatePodGroup.SetNamespace(job.GetNamespace())
-	toCreatePodGroup.SetAnnotations(job.GetAnnotations())
-	toCreatePodGroup.SetOwnerReferences([]metav1.OwnerReference{*jc.GenOwnerReference(job)})
-	if err = specFunc(toCreatePodGroup); err != nil {
-		return nil, fmt.Errorf("unable to fill the spec of PodGroup: %v", err)
+		err = pgctl.CreatePodGroup(newPodGroup)
+		if err != nil {
+			return podGroup, fmt.Errorf("unable to create PodGroup: %v", err)
+		}
+		createdPodGroupsCount.Inc()
 	}
-
-	err = pgctl.CreatePodGroup(toCreatePodGroup)
-	if err != nil {
-		return podGroup, fmt.Errorf("unable to create PodGroup: %v", err)
-	}
-	createdPodGroupsCount.Inc()
 
 	createdPodGroup, err := pgctl.GetPodGroup(job.GetNamespace(), job.GetName())
 	if err != nil {

--- a/pkg/controller.v1/common/scheduling.go
+++ b/pkg/controller.v1/common/scheduling.go
@@ -42,7 +42,7 @@ func (jc *JobController) SyncPodGroup(job metav1.Object, specFunc FillPodGroupSp
 	podGroup, err := pgctl.GetPodGroup(job.GetNamespace(), job.GetName())
 	if err == nil {
 		// update podGroup for gang scheduling
-		oldPodGroup := podGroup
+		oldPodGroup := &podGroup
 		if err = specFunc(podGroup); err != nil {
 			return nil, fmt.Errorf("unable to fill the spec of PodGroup, '%v': %v", klog.KObj(podGroup), err)
 		}


### PR DESCRIPTION
Signed-off-by: Yuki Iwai <yuki.iwai.tz@gmail.com>

Currently, when users update CustomJob resources (e.g, TFJob) with `runPolicy.schedulingPolicy` or `replicas` changes, traininig-operator can not update PodGroup.

This means when hpa-controller updates `replicas`, training-operator does not update PodGroup.

So I implemented the logic to update PodGroup.

/assign @zw0610 @johnugeorge @terrytangyuan 
