### PR TITLE
Upgrade PriorityClass apiVersion to scheduling.k8s.io/v1

### DIFF
--- a/pkg/controller.v1/common/job_controller.go
+++ b/pkg/controller.v1/common/job_controller.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
-	schedulinglisters "k8s.io/client-go/listers/scheduling/v1beta1"
+	schedulinglisters "k8s.io/client-go/listers/scheduling/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"

--- a/pkg/controller.v1/common/service_test.go
+++ b/pkg/controller.v1/common/service_test.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclientset "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
-	schedulinglisters "k8s.io/client-go/listers/scheduling/v1beta1"
+	schedulinglisters "k8s.io/client-go/listers/scheduling/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"

--- a/pkg/controller.v1/common/util.go
+++ b/pkg/controller.v1/common/util.go
@@ -22,7 +22,7 @@ import (
 	apiv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/scheduling/v1beta1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -103,7 +103,7 @@ func AddResourceList(list, req, limit v1.ResourceList) {
 	}
 }
 
-type PriorityClassGetFunc func(string) (*v1beta1.PriorityClass, error)
+type PriorityClassGetFunc func(string) (*schedulingv1.PriorityClass, error)
 
 func CalcPGMinResources(minMember int32, replicas map[apiv1.ReplicaType]*apiv1.ReplicaSpec, pcGetFunc PriorityClassGetFunc) *v1.ResourceList {
 	var replicasPriority ReplicasPriority

--- a/pkg/reconciler.v1/common/gang_scheduler_framework.go
+++ b/pkg/reconciler.v1/common/gang_scheduler_framework.go
@@ -23,7 +23,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/scheduling/v1beta1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -176,8 +176,8 @@ func (r *SchedulerFrameworkReconciler) calcPGMinResources(
 	replicas map[commonv1.ReplicaType]*commonv1.ReplicaSpec,
 ) *corev1.ResourceList {
 	return controllerv1.CalcPGMinResources(minMember, replicas,
-		func(pc string) (*v1beta1.PriorityClass, error) {
-			priorityClass := &v1beta1.PriorityClass{}
+		func(pc string) (*schedulingv1.PriorityClass, error) {
+			priorityClass := &schedulingv1.PriorityClass{}
 			err := r.Get(context.TODO(), types.NamespacedName{Name: pc}, priorityClass)
 			return priorityClass, err
 		})

--- a/pkg/reconciler.v1/common/gang_volcano.go
+++ b/pkg/reconciler.v1/common/gang_volcano.go
@@ -24,7 +24,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/scheduling/v1beta1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -193,8 +193,8 @@ func (r *VolcanoReconciler) DecoratePodForGangScheduling(rtype string, podTempla
 
 // calcPGMinResources calculates the minimal resources needed for this job. The value will be embedded into the associated PodGroup
 func (r *VolcanoReconciler) calcPGMinResources(minMember int32, replicas map[commonv1.ReplicaType]*commonv1.ReplicaSpec) *corev1.ResourceList {
-	pcGetFunc := func(pc string) (*v1beta1.PriorityClass, error) {
-		priorityClass := &v1beta1.PriorityClass{}
+	pcGetFunc := func(pc string) (*schedulingv1.PriorityClass, error) {
+		priorityClass := &schedulingv1.PriorityClass{}
 		err := r.Get(context.Background(), types.NamespacedName{Name: pc}, priorityClass)
 		return priorityClass, err
 	}


### PR DESCRIPTION
Signed-off-by: Yuki Iwai <yuki.iwai.tz@gmail.com>

I upgraded PriorityClass apiVersion to scheduling.k8s.io/v1 since scheduling.k8s.io/v1beta1 was removed in Kubernetes v1.22.

ref: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22

Fixes: #156 
