### PR TITLE
Make scheduler-plugins the default gang scheduler

### DIFF
--- a/pkg/controller.v1/common/job.go
+++ b/pkg/controller.v1/common/job.go
@@ -275,7 +275,7 @@ func (jc *JobController) ReconcileJobs(
 					pg = volcanoPodGroup
 					return nil
 				}
-			case GangSchedulerSchedulerPlugins:
+			default:
 				pgSpecFill = func(pg metav1.Object) error {
 					schedulerPluginsPodGroup, match := pg.(*schedulerpluginsv1alpha1.PodGroup)
 					if !match {

--- a/pkg/controller.v1/common/job_controller.go
+++ b/pkg/controller.v1/common/job_controller.go
@@ -69,8 +69,9 @@ var (
 type GangScheduler string
 
 const (
-	GangSchedulerNone             GangScheduler = "None"
-	GangSchedulerVolcano          GangScheduler = "volcano"
+	GangSchedulerNone    GangScheduler = "None"
+	GangSchedulerVolcano GangScheduler = "volcano"
+	// GangSchedulerSchedulerPlugins Using this scheduler name or any scheduler name different than volcano uses the scheduler-plugins PodGroup
 	GangSchedulerSchedulerPlugins GangScheduler = "scheduler-plugins"
 )
 
@@ -81,7 +82,7 @@ type JobControllerConfiguration struct {
 }
 
 func (c *JobControllerConfiguration) EnableGangScheduling() bool {
-	return c.GangScheduling != GangSchedulerNone
+	return c.GangScheduling != "" && c.GangScheduling != GangSchedulerNone
 }
 
 // JobController abstracts other operators to manage the lifecycle of Jobs.
@@ -170,16 +171,16 @@ var GenVolcanoSetupFunc = func(vci volcanoclient.Interface) GangSchedulingSetupF
 	}
 }
 
-var GenSchedulerPluginsSetupFunc = func(c client.Client) GangSchedulingSetupFunc {
+var GenSchedulerPluginsSetupFunc = func(c client.Client, gangSchedulerName string) GangSchedulingSetupFunc {
 	return func(jc *JobController) {
-		jc.Config.GangScheduling = GangSchedulerSchedulerPlugins
-		jc.PodGroupControl = control.NewSchedulerPluginsControl(c)
+		jc.Config.GangScheduling = GangScheduler(gangSchedulerName)
+		jc.PodGroupControl = control.NewSchedulerPluginsControl(c, gangSchedulerName)
 	}
 }
 
 var GenNonGangSchedulerSetupFunc = func() GangSchedulingSetupFunc {
 	return func(jc *JobController) {
-		jc.Config.GangScheduling = GangSchedulerNone
+		jc.Config.GangScheduling = ""
 		jc.PodGroupControl = nil
 	}
 }
@@ -210,7 +211,7 @@ func NewJobController(
 
 	jc := JobController{
 		Controller:     controllerImpl,
-		Config:         JobControllerConfiguration{GangScheduling: GangSchedulerNone},
+		Config:         JobControllerConfiguration{},
 		PodControl:     podControl,
 		ServiceControl: serviceControl,
 		KubeClientSet:  kubeClientSet,

--- a/pkg/controller.v1/common/pod.go
+++ b/pkg/controller.v1/common/pod.go
@@ -421,7 +421,7 @@ func (jc *JobController) createNewPod(job interface{}, rt string, index int, spe
 
 	// if gang-scheduling is enabled:
 	// 1. if user has specified other scheduler, we report a warning without overriding any fields.
-	// 2. if no SchedulerName is set for pods, then we set the SchedulerName to "volcano".
+	// 2. if no SchedulerName is set for pods, we set the SchedulerName to gang-scheduler-name.
 	if jc.Config.EnableGangScheduling() {
 		if isCustomSchedulerSet(replicas, jc.PodGroupControl.GetSchedulerName()) {
 			errMsg := "Another scheduler is specified when gang-scheduling is enabled and it will not be overwritten"

--- a/pkg/controller.v1/control/podgroup_control.go
+++ b/pkg/controller.v1/control/podgroup_control.go
@@ -125,10 +125,15 @@ var _ PodGroupControlInterface = &VolcanoControl{}
 
 // SchedulerPluginsControl is the  implementation of PodGroupControlInterface with scheduler-plugins.
 type SchedulerPluginsControl struct {
-	Client client.Client
+	Client        client.Client
+	SchedulerName string
 }
 
 func (s *SchedulerPluginsControl) DecoratePodTemplateSpec(pts *corev1.PodTemplateSpec, job metav1.Object, _ string) {
+	if len(pts.Spec.SchedulerName) == 0 {
+		pts.Spec.SchedulerName = s.GetSchedulerName()
+	}
+
 	if pts.Labels == nil {
 		pts.Labels = make(map[string]string)
 	}
@@ -136,12 +141,12 @@ func (s *SchedulerPluginsControl) DecoratePodTemplateSpec(pts *corev1.PodTemplat
 }
 
 func (s *SchedulerPluginsControl) GetSchedulerName() string {
-	return ""
+	return s.SchedulerName
 }
 
 // NewSchedulerPluginsControl returns a SchedulerPluginsControl
-func NewSchedulerPluginsControl(c client.Client) PodGroupControlInterface {
-	return &SchedulerPluginsControl{Client: c}
+func NewSchedulerPluginsControl(c client.Client, schedulerName string) PodGroupControlInterface {
+	return &SchedulerPluginsControl{Client: c, SchedulerName: schedulerName}
 }
 
 func (s *SchedulerPluginsControl) DelayPodCreationDueToPodGroup(pg metav1.Object) bool {

--- a/pkg/reconciler.v1/common/gang_scheduler_framework.go
+++ b/pkg/reconciler.v1/common/gang_scheduler_framework.go
@@ -38,6 +38,7 @@ type SchedulerFrameworkReconciler struct {
 	BaseGangReconciler
 	ReconcilerUtilInterface
 	client.Client
+	SchedulerName string
 }
 
 func BareSchedulerFrameworkReconciler(client client.Client, bgReconciler *BaseGangReconciler, enabled bool) *SchedulerFrameworkReconciler {
@@ -57,9 +58,9 @@ func (r *SchedulerFrameworkReconciler) OverrideForGangSchedulingInterface(ui Rec
 	}
 }
 
-// GetGangSchedulerName returns the name of Gang Scheduler will be used, which is "" for SchedulerFrameworkReconciler
+// GetGangSchedulerName returns the name of Gang Scheduler will be used.
 func (r *SchedulerFrameworkReconciler) GetGangSchedulerName() string {
-	return ""
+	return r.SchedulerName
 }
 
 // GangSchedulingEnabled returns if gang-scheduling is enabled for all jobs
@@ -164,6 +165,10 @@ func (r *SchedulerFrameworkReconciler) DecoratePodForGangScheduling(
 	podTemplate *corev1.PodTemplateSpec,
 	job client.Object,
 ) {
+	if podTemplate.Spec.SchedulerName == "" {
+		podTemplate.Spec.SchedulerName = r.GetGangSchedulerName()
+	}
+
 	if podTemplate.Labels == nil {
 		podTemplate.Labels = make(map[string]string)
 	}


### PR DESCRIPTION
**What this PR does / why we need it:**

Now supports many gang schedulers(volcano, scheduler-plugins). This PR supports koordinator gang scheduler. 

Related: https://github.com/kubeflow/training-operator/issues/1746