### PR TITLE
Pod name using generated name

### DIFF
--- a/pkg/controller.v1/common/pod.go
+++ b/pkg/controller.v1/common/pod.go
@@ -396,7 +396,7 @@ func (jc *JobController) createNewPod(job interface{}, rt string, index int, spe
 
 	idxStr := strconv.Itoa(index)
 	// Set name for the template.
-	podTemplate.Name = GenGeneralName(metaObject.GetName(), rt, idxStr)
+	podTemplate.GenerateName = GenGeneralNamePrefix(metaObject.GetName(), rt, idxStr)
 
 	if podTemplate.Labels == nil {
 		podTemplate.Labels = make(map[string]string)

--- a/pkg/controller.v1/common/service.go
+++ b/pkg/controller.v1/common/service.go
@@ -239,6 +239,7 @@ func (jc *JobController) CreateNewService(job metav1.Object, rtype apiv1.Replica
 		service.Spec.Ports = append(service.Spec.Ports, svcPort)
 	}
 
+	//service name can't use the generated name, tensorflow using svc name for discovery.
 	service.Name = GenGeneralName(job.GetName(), rt, index)
 	service.Labels = labels
 	// Create OwnerReference.

--- a/pkg/controller.v1/common/util.go
+++ b/pkg/controller.v1/common/util.go
@@ -47,6 +47,11 @@ func (p ReplicasPriority) Swap(i, j int) {
 	p[i], p[j] = p[j], p[i]
 }
 
+func GenGeneralNamePrefix(jobName string, rtype string, index string) string {
+	n := jobName + "-" + strings.ToLower(rtype) + "-" + index + "-"
+	return strings.Replace(n, "/", "-", -1)
+}
+
 func GenGeneralName(jobName string, rtype string, index string) string {
 	n := jobName + "-" + strings.ToLower(rtype) + "-" + index
 	return strings.Replace(n, "/", "-", -1)

--- a/pkg/controller.v1/control/pod_control.go
+++ b/pkg/controller.v1/control/pod_control.go
@@ -21,7 +21,7 @@ import (
 
 	commonutil "github.com/kubeflow/common/pkg/util"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -129,6 +129,9 @@ func GetPodFromTemplate(template *v1.PodTemplateSpec, parentObject runtime.Objec
 			Name:        template.Name,
 			Finalizers:  desiredFinalizers,
 		},
+	}
+	if template.GenerateName != "" {
+		pod.ObjectMeta.GenerateName = template.GenerateName
 	}
 	if controllerRef != nil {
 		pod.OwnerReferences = append(pod.OwnerReferences, *controllerRef)

--- a/pkg/controller.v1/control/utils.go
+++ b/pkg/controller.v1/control/utils.go
@@ -18,6 +18,7 @@ package control
 
 import (
 	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
If a job is recreated using the deleted job name, while the deleted job pods are still in `Terminating` state, the new job pod will create fail. So we'd better using generated pod name. I found the kubernetes Job implementation is also using the generated pod name.