### PR TITLE
Fix all lint errors

### DIFF
--- a/pkg/controller.v1/common/job.go
+++ b/pkg/controller.v1/common/job.go
@@ -97,7 +97,9 @@ func (jc *JobController) ReconcileJobs(
 	//    and it's safe to reset the expectations
 	// 2. Reset expectations can avoid dirty data such as `expectedDeletion = -1`
 	//    (pod or service was deleted unexpectedly)
-	jc.ResetExpectations(jobKey, replicas)
+	if err = jc.ResetExpectations(jobKey, replicas); err != nil {
+		log.Warnf("Failed to reset expectations: %v", err)
+	}
 
 	log.Infof("Reconciling for job %s", metaObject.GetName())
 	pods, err := jc.Controller.GetPodsForJob(job)
@@ -258,7 +260,7 @@ func (jc *JobController) ReconcileJobs(
 				minResources = jc.calcPGMinResources(minMember, replicas)
 			}
 
-			var pgSpecFill FillPodGroupSpecFunc = nil
+			var pgSpecFill FillPodGroupSpecFunc
 			switch jc.Config.GangScheduling {
 			case GangSchedulerVolcano:
 				pgSpecFill = func(pg metav1.Object) error {
@@ -272,7 +274,6 @@ func (jc *JobController) ReconcileJobs(
 						PriorityClassName: priorityClass,
 						MinResources:      minResources,
 					}
-					pg = volcanoPodGroup
 					return nil
 				}
 			default:
@@ -286,7 +287,6 @@ func (jc *JobController) ReconcileJobs(
 						MinResources:           *minResources,
 						ScheduleTimeoutSeconds: schedulerTimeout,
 					}
-					pg = schedulerPluginsPodGroup
 					return nil
 				}
 			}
@@ -343,13 +343,19 @@ func (jc *JobController) ReconcileJobs(
 }
 
 // ResetExpectations reset the expectation for creates and deletes of pod/service to zero.
-func (jc *JobController) ResetExpectations(jobKey string, replicas map[apiv1.ReplicaType]*apiv1.ReplicaSpec) {
+func (jc *JobController) ResetExpectations(jobKey string, replicas map[apiv1.ReplicaType]*apiv1.ReplicaSpec) error {
+	var allErrs error
 	for rtype := range replicas {
 		expectationPodsKey := expectation.GenExpectationPodsKey(jobKey, string(rtype))
-		jc.Expectations.SetExpectations(expectationPodsKey, 0, 0)
+		if err := jc.Expectations.SetExpectations(expectationPodsKey, 0, 0); err != nil {
+			allErrs = err
+		}
 		expectationServicesKey := expectation.GenExpectationServicesKey(jobKey, string(rtype))
-		jc.Expectations.SetExpectations(expectationServicesKey, 0, 0)
+		if err := jc.Expectations.SetExpectations(expectationServicesKey, 0, 0); err != nil {
+			allErrs = fmt.Errorf("%s: %w", allErrs.Error(), err)
+		}
 	}
+	return allErrs
 }
 
 // PastActiveDeadline checks if job has ActiveDeadlineSeconds field set and if it is exceeded.

--- a/pkg/controller.v1/common/service_test.go
+++ b/pkg/controller.v1/common/service_test.go
@@ -106,8 +106,7 @@ func TestJobController_CreateNewService(t *testing.T) {
 		index string
 	}
 
-	var replicas int32
-	replicas = 2
+	var replicas int32 = 2
 	tests := []struct {
 		name    string
 		fields  fields

--- a/pkg/controller.v1/control/podgroup_control.go
+++ b/pkg/controller.v1/control/podgroup_control.go
@@ -113,9 +113,8 @@ func (v *VolcanoControl) UpdatePodGroup(podGroup client.Object) error {
 
 func (v *VolcanoControl) CreatePodGroup(podGroup client.Object) error {
 	pg := podGroup.(*volcanov1beta1.PodGroup)
-	createPodGroup, err := v.Client.SchedulingV1beta1().PodGroups(pg.GetNamespace()).Create(context.TODO(), pg, metav1.CreateOptions{})
+	_, err := v.Client.SchedulingV1beta1().PodGroups(pg.GetNamespace()).Create(context.TODO(), pg, metav1.CreateOptions{})
 	if err != nil {
-		podGroup = createPodGroup
 		return fmt.Errorf("unable to create PodGroup: %v", err)
 	}
 	return nil

--- a/pkg/controller.v1/expectation/expectation_test.go
+++ b/pkg/controller.v1/expectation/expectation_test.go
@@ -98,7 +98,9 @@ func TestControllerExpectations(t *testing.T) {
 	rcKey, err := KeyFunc(rc)
 	assert.NoError(t, err, "Couldn't get key for object %#v: %v", rc, err)
 
-	e.SetExpectations(rcKey, adds, dels)
+	err = e.SetExpectations(rcKey, adds, dels)
+	assert.NoError(t, err, "Could not register expectations for rc, err: %v", err)
+
 	var wg sync.WaitGroup
 	for i := 0; i < adds+1; i++ {
 		wg.Add(1)
@@ -134,7 +136,8 @@ func TestControllerExpectations(t *testing.T) {
 	assert.True(t, e.SatisfiedExpectations(rcKey), "Expectations are met but the rc will not sync")
 
 	// Next round of rc sync, old expectations are cleared
-	e.SetExpectations(rcKey, 1, 2)
+	err = e.SetExpectations(rcKey, 1, 2)
+	assert.NoError(t, err, "Could not register expectations for rc, err %v", err)
 	podExp, exists, err = e.GetExpectations(rcKey)
 	assert.NoError(t, err, "Could not get expectations for rc, exists %v and err %v", exists, err)
 	assert.True(t, exists, "Could not get expectations for rc, exists %v and err %v", exists, err)

--- a/pkg/reconciler.v1/common/job.go
+++ b/pkg/reconciler.v1/common/job.go
@@ -125,7 +125,7 @@ func (r *JobReconciler) ReconcileJob(
 
 	oldStatus := status.DeepCopy()
 
-	var err error = nil
+	var err error
 	if r.ShouldCleanUp(*status) {
 		if err = r.CleanupResources(runPolicy, *status, job); err != nil {
 			return err

--- a/pkg/reconciler.v1/common/pod.go
+++ b/pkg/reconciler.v1/common/pod.go
@@ -274,5 +274,4 @@ func (r *PodReconciler) DeletePod(ctx context.Context, ns string, name string) e
 // DecoratePod decorates podTemplate before a Pod is submitted to the APIServer
 func (r *PodReconciler) DecoratePod(rtype string, podTemplate *corev1.PodTemplateSpec, job client.Object) {
 	// Default implementation applies nothing to podTemplate
-	return
 }

--- a/pkg/reconciler.v1/common/service.go
+++ b/pkg/reconciler.v1/common/service.go
@@ -222,5 +222,4 @@ func (r *ServiceReconciler) DeleteService(ns string, name string, job client.Obj
 // DecorateService decorates the Service before it's submitted to APIServer
 func (r *ServiceReconciler) DecorateService(rtype string, svc *corev1.Service, job client.Object) {
 	// Default implementation applies nothing to podTemplate
-	return
 }


### PR DESCRIPTION
I fixed all lint errors that can be caught with `golangci-lint run --timeout 5m --go 1.19 ./...`.

/assign @johnugeorge 
